### PR TITLE
Align /lib/templates/robotframework to naming convention for keywords…

### DIFF
--- a/lib/config/robotframework.conf
+++ b/lib/config/robotframework.conf
@@ -1,12 +1,12 @@
 [_common]
 template_dirs = robotframework, python, common
-indentation = "\t"
+indentation = "   "
 
 [tests]
-filename = 'test_project.txt'
-named_filename = 'test_%s.txt'
-filename_convention = 'underscore'
+filename = 'project.robot'
+named_filename = '%s.robot'
+filename_convention = 'camelize'
 
 [actionwords]
-filename = 'keywords.txt'
-naming_convention = 'underscore'
+filename = 'keywords.robot'
+naming_convention = 'normalize_with_spaces'

--- a/lib/templates/robotframework/_keyword.hbs
+++ b/lib/templates/robotframework/_keyword.hbs
@@ -1,1 +1,1 @@
-{{{ underscore rendered_children.name }}}{{#if rendered_children.uid}}_uid{{{ normalize rendered_children.uid}}}{{/if}}{{> keyword_body}}
+{{{ normalize_with_spaces rendered_children.name }}}{{#if rendered_children.uid}}_uid{{{ normalize rendered_children.uid}}}{{/if}}{{> keyword_body}}

--- a/lib/templates/robotframework/_keyword_body.hbs
+++ b/lib/templates/robotframework/_keyword_body.hbs
@@ -1,4 +1,4 @@
 {{#indent}}
-{{#if has_parameters?}}[Arguments]{{{ tab }}}{{{ join rendered_children.parameters "\t"}}}
+{{#if has_parameters?}}[Arguments]{{{ tab }}}{{{ join rendered_children.parameters "    "}}}
 {{/if}}{{#each rendered_children.body}}{{{ this }}}
 {{/each}}{{/indent}}

--- a/lib/templates/robotframework/actionword.hbs
+++ b/lib/templates/robotframework/actionword.hbs
@@ -1,1 +1,1 @@
-{{{ underscore rendered_children.name }}}{{> keyword_body}}
+{{{ normalize_with_spaces rendered_children.name }}}{{> keyword_body}}

--- a/lib/templates/robotframework/call.hbs
+++ b/lib/templates/robotframework/call.hbs
@@ -1,1 +1,1 @@
-{{{ underscore rendered_children.actionword }}}{{#if has_arguments?}}{{tab}}{{{ join rendered_children.arguments '\t'}}}{{/if}}
+{{{ normalize_with_spaces rendered_children.actionword }}}{{#if has_arguments?}}    {{{ join rendered_children.arguments '    '}}}{{/if}}

--- a/lib/templates/robotframework/dataset.hbs
+++ b/lib/templates/robotframework/dataset.hbs
@@ -1,1 +1,1 @@
-{{{ rendered_children.name}}}{{#if rendered_children.uid}} (uid:{{{rendered_children.uid}}}){{/if}}{{{ tab }}}{{{ join rendered_children.arguments '\t'}}}
+{{{ rendered_children.name}}}{{#if rendered_children.uid}} (uid:{{{rendered_children.uid}}}){{/if}}{{{ tab }}}{{{ join rendered_children.arguments '    '}}}

--- a/lib/templates/robotframework/folder.hbs
+++ b/lib/templates/robotframework/folder.hbs
@@ -5,15 +5,15 @@ Documentation
 {{#if has_tags?}}
 Tags: {{{ join rendered_children.tags ' '}}}
 {{/if}}{{/clear_empty_lines}}{{/comment}}
-Resource          keywords.txt
+Resource          keywords.robot
 {{#unless is_empty?}}
-Test Setup{{tab}}Run Keywords{{tab}}{{join rendered_children.body "\n...         AND      \t"}}
+Test Setup    Run Keywords    {{join rendered_children.body "\n...         AND          "}}
 {{/unless}}
 *** Test Cases ***{{#if datatables_present?}}
 {{#each rendered_children.splitted_scenarios}}
 {{#if this.datatable}}{{#each this.datasets}}{{normalize_with_spaces this.scenario_name}} {{normalize_with_spaces this.name}}{{#if this.uid}} (uid:{{normalize this.uid}}){{/if}}{{#indent}}
-[Template]{{tab}}{{normalize_with_spaces this.scenario_name}} keyword
-{{join this.arguments '\t'}}{{/indent}}
+[Template]    {{normalize_with_spaces this.scenario_name}} keyword
+{{join this.arguments '    '}}{{/indent}}
 
 {{/each}}
 {{else}}{{normalize_with_spaces this.name}}{{#if this.uid}}(uid:{{normalize this.uid}}){{/if}}{{#indent}}
@@ -22,7 +22,7 @@ Test Setup{{tab}}Run Keywords{{tab}}{{join rendered_children.body "\n...        
 *** Keywords ***
 
 {{#each rendered_children.splitted_scenarios}}{{#if this.datatable}}{{normalize_with_spaces this.name}} keyword{{#indent}}
-[Arguments]{{tab}}{{join this.parameters '\t'}}
+[Arguments]    {{join this.parameters '    '}}
 {{join this.body '\n'}}{{/indent}}
 
 {{/if}}{{/each}}{{else}}

--- a/lib/templates/robotframework/parameter.hbs
+++ b/lib/templates/robotframework/parameter.hbs
@@ -1,1 +1,1 @@
-${{#curly}}{{{ underscore rendered_children.name }}}{{/curly}}{{#if has_default_value?}}={{{ rendered_children.default }}}{{/if}}
+${{#curly}}{{{ normalize_with_spaces rendered_children.name }}}{{/curly}}{{#if has_default_value?}}={{{ rendered_children.default }}}{{/if}}

--- a/lib/templates/robotframework/scenarios.hbs
+++ b/lib/templates/robotframework/scenarios.hbs
@@ -1,10 +1,10 @@
 *** Settings ***
-Resource          keywords.txt
+Resource          keywords.robot
 
 *** Test Cases ***{{#if datatables_present?}}
 {{#each rendered_children.splitted_scenarios}}
 {{#if this.datatable}}{{this.name}}{{#indent}}
-[Template]{{tab}}{{this.name}} keyword
+[Template]    {{this.name}} keyword
 {{this.datatable}}{{/indent}}
 {{else}}{{normalize_with_spaces this.name}}{{#if rendered_children.uid}} (uid:{{normalize rendered_children.uid}}){{/if}}{{#indent}}
 {{join this.body '\n'}}{{/indent}}
@@ -12,7 +12,7 @@ Resource          keywords.txt
 *** Keywords ***
 
 {{#each rendered_children.splitted_scenarios}}{{#if this.datatable}}{{normalize_with_spaces this.name}} keyword{{#indent}}
-[Arguments]{{tab}}${{#curly}}__test_name{{/curly}}{{tab}}{{join this.parameters '\t'}}
+[Arguments]    ${{#curly}}__test_name{{/curly}}    {{join this.parameters '    '}}
 {{join this.body '\n'}}{{/indent}}
 
 {{/if}}{{/each}}{{else}}

--- a/lib/templates/robotframework/single_scenario.hbs
+++ b/lib/templates/robotframework/single_scenario.hbs
@@ -6,6 +6,6 @@ Documentation
 Tags: {{{ join rendered_children.tags ' '}}}
 {{/if}}{{/clear_empty_lines}}{{/comment}}
 
-Resource          keywords.txt
+Resource          keywords.robot
 
 {{> scenario}}

--- a/lib/templates/robotframework/single_test.hbs
+++ b/lib/templates/robotframework/single_test.hbs
@@ -6,6 +6,6 @@ Documentation
 Tags: {{{ join rendered_children.tags ' '}}}
 {{/if}}{{/clear_empty_lines}}{{/comment}}
 
-Resource          keywords.txt
+Resource          keywords.robot
 
 {{> scenario}}

--- a/lib/templates/robotframework/tests.hbs
+++ b/lib/templates/robotframework/tests.hbs
@@ -1,5 +1,5 @@
 *** Settings ***
-Resource          keywords.txt
+Resource          keywords.robot
 
 *** Test Cases ***
 {{#each rendered_children.tests}}

--- a/lib/templates/robotframework/variable.hbs
+++ b/lib/templates/robotframework/variable.hbs
@@ -1,1 +1,1 @@
-${{#curly}}{{ underscore rendered_children.name }}{{/curly}}
+${{#curly}}{{ normalize_with_spaces rendered_children.name }}{{/curly}}


### PR DESCRIPTION
… (i.e. normalize_with_spaces) and files (i.e. Camelize.robot) with language. Replaced tabs with 4 spaces for consistent spacing.