### PR TITLE
Spock: Actionword should return true

### DIFF
--- a/lib/templates/groovy/_steps.hbs
+++ b/lib/templates/groovy/_steps.hbs
@@ -1,4 +1,4 @@
 
 {{#each rendered_children.body}}{{{this}}}
 {{/each}}{{#if has_step?}}
-throw new UnsupportedOperationException(){{/if}}
+  assert false, "Not Implemented, remove this line when done."{{/if}}

--- a/lib/templates/groovy/actionword.hbs
+++ b/lib/templates/groovy/actionword.hbs
@@ -1,2 +1,3 @@
-def {{{camelize_lower rendered_children.name }}}({{#if has_parameters?}}{{{join rendered_children.parameters ', '}}}{{/if}}) {{#curly}}{{#indent}}{{> desc}}{{> steps}}{{/indent}}
+boolean {{{camelize_lower rendered_children.name }}}({{#if has_parameters?}}{{{join rendered_children.parameters ', '}}}{{/if}}) {{#curly}}{{#indent}}{{> desc}}{{> steps}}{{/indent}}
+	true
 {{/curly}}


### PR DESCRIPTION
Spocks expect-block defines an automatic assertion-behavior, thus requiring a statement to return a boolean expression.
Since Actionwords can be reused in any sense it happens that an Actionword is used within an expect-block, hence the Actionword must return true.

Hiptest-Publisher should honor this behavior by generating true as the last statement in the stub. This alone will cause compilation errors when throwing UnsupportedOperationExceptions, thus requiring a change to the _steps template as well which should rather generate a failing assert (including message)

Signed-off-by: Marc Schlegel marc.schlegel@gmx.de