### PR TITLE
Add new language & framework for more recent cucumber-js, w/ ES6 modules

### DIFF
--- a/lib/config/cucumber-esmodules.conf
+++ b/lib/config/cucumber-esmodules.conf
@@ -1,0 +1,21 @@
+[_common]
+indentation = '    '
+fallback_template = 'empty'
+
+[features]
+node_name = folders
+template_dirs = gherkin/inlined_uids, gherkin, common
+named_filename = '%s.feature'
+indentation = '  '
+
+[step_definitions]
+node_name = actionwords
+template_dirs = cucumber/esmodules, javascript, common
+filename = 'step_definitions.js'
+naming_convention = 'camelize_lower'
+call_prefix = 'actionwords'
+
+[actionwords]
+template_dirs = javascript/esmodules, javascript, common
+filename = 'actionwords.js'
+naming_convention = 'camelize_lower'

--- a/lib/templates/cucumber/esmodules/actionword.hbs
+++ b/lib/templates/cucumber/esmodules/actionword.hbs
@@ -1,5 +1,5 @@
 {{#if rendered_children.gherkin_annotation }}
 {{{ rendered_children.gherkin_annotation }}}(/{{> gherkin_pattern}}/, function ({{#if rendered_children.parameters}}{{{ join rendered_children.parameters_ordered_by_pattern ', '}}}{{/if}}) {{#curly}}{{#indent}}
-return actionwords.{{{camelize_lower rendered_children.name}}}({{#if has_parameters?}}{{#join raw_parameter_names ', '}}{{{underscore this}}}{{/join}}{{/if}});
+return {{context.call_prefix}}.{{{camelize_lower rendered_children.name}}}({{#if has_parameters?}}{{#join raw_parameter_names ', '}}{{{underscore this}}}{{/join}}{{/if}});
 {{/indent}}
 {{/curly}});{{/if}}

--- a/lib/templates/cucumber/esmodules/actionword.hbs
+++ b/lib/templates/cucumber/esmodules/actionword.hbs
@@ -1,0 +1,5 @@
+{{#if rendered_children.gherkin_annotation }}
+{{{ rendered_children.gherkin_annotation }}}(/{{> gherkin_pattern}}/, function ({{#if rendered_children.parameters}}{{{ join rendered_children.parameters_ordered_by_pattern ', '}}}{{/if}}) {{#curly}}{{#indent}}
+return actionwords.{{{camelize_lower rendered_children.name}}}({{#if has_parameters?}}{{#join raw_parameter_names ', '}}{{{underscore this}}}{{/join}}{{/if}});
+{{/indent}}
+{{/curly}});{{/if}}

--- a/lib/templates/cucumber/esmodules/actionwords.hbs
+++ b/lib/templates/cucumber/esmodules/actionwords.hbs
@@ -1,5 +1,5 @@
 import {{#curly}} Given, When, Then {{/curly}} from 'cucumber';
-import * as actionwords from './actionwords'
+import * as actionwords from './actionwords';
 
 {{#each rendered_children.actionwords}}{{{this}}}
 {{/each}}

--- a/lib/templates/cucumber/esmodules/actionwords.hbs
+++ b/lib/templates/cucumber/esmodules/actionwords.hbs
@@ -1,5 +1,5 @@
 import {{#curly}} Given, When, Then {{/curly}} from 'cucumber';
-import * as actionwords from './actionwords';
+import * as {{context.call_prefix}} from './{{context.call_prefix}}';
 
 {{#each rendered_children.actionwords}}{{{this}}}
 {{/each}}

--- a/lib/templates/cucumber/esmodules/actionwords.hbs
+++ b/lib/templates/cucumber/esmodules/actionwords.hbs
@@ -1,0 +1,5 @@
+import {{#curly}} Given, When, Then {{/curly}} from 'cucumber';
+import * as actionwords from './actionwords'
+
+{{#each rendered_children.actionwords}}{{{this}}}
+{{/each}}

--- a/lib/templates/javascript/esmodules/_item_as_async_function.hbs
+++ b/lib/templates/javascript/esmodules/_item_as_async_function.hbs
@@ -1,3 +1,3 @@
-export async function {{ camelize_lower rendered_children.name }} ({{{ join rendered_children.parameters ', '}}}) {{#curly}}
+export async function {{ camelize_lower rendered_children.name }} ({{#if has_parameters?}}{{{ join rendered_children.parameters ', '}}}{{/if}}) {{#curly}}
 {{> body}}
 {{/curly}}

--- a/lib/templates/javascript/esmodules/_item_as_async_function.hbs
+++ b/lib/templates/javascript/esmodules/_item_as_async_function.hbs
@@ -1,0 +1,3 @@
+export async function {{ camelize_lower rendered_children.name }} ({{{ join rendered_children.parameters ', '}}}) {{#curly}}
+{{> body}}
+{{/curly}}

--- a/lib/templates/javascript/esmodules/actionword.hbs
+++ b/lib/templates/javascript/esmodules/actionword.hbs
@@ -1,0 +1,1 @@
+{{> item_as_async_function}}

--- a/lib/templates/javascript/esmodules/actionwords.hbs
+++ b/lib/templates/javascript/esmodules/actionwords.hbs
@@ -1,0 +1,3 @@
+{{#join rendered_children.actionwords ";
+"}}
+{{{this}}}{{/join}}

--- a/lib/templates/javascript/esmodules/call.hbs
+++ b/lib/templates/javascript/esmodules/call.hbs
@@ -1,0 +1,2 @@
+{{#if has_annotation? }}{{#comment '//'}}{{{ rendered_children.gherkin_text }}}{{/comment}}
+{{/if}}await {{#if context.call_prefix}}{{{ context.call_prefix }}}.{{/if}}{{{ camelize_lower rendered_children.actionword }}}({{{ join rendered_children.all_arguments ', '}}});

--- a/spec/render/cucumber_spec.rb
+++ b/spec/render/cucumber_spec.rb
@@ -285,3 +285,68 @@ describe 'Cucumber/Javascript rendering' do
     let(:rendered_empty_scenario) { "\nScenario: Empty Scenario\n" }
   end
 end
+
+describe 'Cucumber/ECMAScript 2015 Modules rendering' do
+  it_behaves_like 'a BDD renderer', uid_should_be_in_outline: true do
+    let(:language) {'cucumber'}
+    let(:framework) {'esmodules'}
+
+    let(:rendered_free_texted_actionword) {[
+      'export async function theFollowingUsersAreAvailable (__free_text) {',
+      '',
+      '}'].join("\n")}
+
+    let(:rendered_datatabled_actionword) {[
+      'export async function theFollowingUsersAreAvailable (__datatable) {',
+      '',
+      '}'].join("\n")}
+
+    let(:rendered_actionwords) {
+      [
+        'import { Given, When, Then } from \'cucumber\';',
+        'import * as actionwords from \'./actionwords\';',
+        '',
+        '',
+        'Given(/^the color "(.*)"$/, function (color) {',
+        '    return actionwords.theColorColor(color);',
+        '});',
+        '',
+        'When(/^you mix colors$/, function () {',
+        '    return actionwords.youMixColors();',
+        '});',
+        '',
+        'Then(/^you obtain "(.*)"$/, function (color) {',
+        '    return actionwords.youObtainColor(color);',
+        '});',
+        '',
+        '',
+        'Then(/^you cannot play croquet$/, function () {',
+        '    return actionwords.youCannotPlayCroquet();',
+        '});',
+        '',
+        'Given(/^I am on the "(.*)" home page$/, function (site, __free_text) {',
+        '    return actionwords.iAmOnTheSiteHomePage(site, __free_text);',
+        '});',
+        '',
+        'When(/^the following users are available on "(.*)"$/, function (site, __datatable) {',
+        '    return actionwords.theFollowingUsersAreAvailableOnSite(site, __datatable);',
+        '});',
+        '',
+        'Given(/^an untrimed action word$/, function () {',
+        '    return actionwords.anUntrimedActionWord();',
+        '});',
+        '',
+        'Given(/^the "(.*)" of "(.*)" is weird "(.*)" "(.*)"$/, function (order, parameters, p0, p1) {',
+        '    return actionwords.theOrderOfParametersIsWeird(p0, p1, parameters, order);',
+        '});',
+        '',
+        'Given(/^I login on "(.*)" "(.*)"$/, function (site, username) {',
+        '    return actionwords.iLoginOn(site, username);',
+        '});',
+        ''
+      ].join("\n")
+    }
+
+    let(:rendered_empty_scenario) { "\nScenario: Empty Scenario\n" }
+  end
+end


### PR DESCRIPTION
*Reason*: The provided `cucumber-js` support uses syntax that had been deprecated as of v2, in favor of `defineSupportCode` through the life of v3, which then was dropped at v4 in favor of requiring/importing and using the `Given`/`When`/`Then` methods directly.

I didn't want to needlessly inconvenience anyone still using this older version of the cucumber-js framework, so I added a new one and took liberties to enhance it with some modern Javascript syntax to match what we are using in our project with [Webdriver.io](https://github.com/webdriverio/webdriverio).