### PR TITLE
Python unittest formatting

### DIFF
--- a/lib/templates/python/_body.hbs
+++ b/lib/templates/python/_body.hbs
@@ -1,8 +1,8 @@
 {{#clear_empty_lines}}
 {{#indent}}
-{{#comment '#'}}{{#if has_description?}}{{{ rendered_children.description }}}
+'''{{#if has_description?}}{{{ rendered_children.description }}}
 {{/if}}{{#if has_tags?}}Tags: {{{ join rendered_children.tags ' '}}}
-{{/if}}{{/comment}}
+{{/if}}'''
 {{#each rendered_children.body}}{{{this}}}
 {{/each}}
 {{#if has_step?}}raise NotImplementedError{{/if}}

--- a/lib/templates/python/argument.hbs
+++ b/lib/templates/python/argument.hbs
@@ -1,1 +1,1 @@
-{{#escape_new_line}}{{#trim_surrounding_characters "__"}}{{{ underscore rendered_children.name }}}{{/trim_surrounding_characters}} = {{{ rendered_children.value }}}{{/escape_new_line}}
+{{#escape_new_line}}{{#trim_surrounding_characters "__"}}{{{ underscore rendered_children.name }}}{{/trim_surrounding_characters}}={{{ rendered_children.value }}}{{/escape_new_line}}

--- a/lib/templates/python/parameter.hbs
+++ b/lib/templates/python/parameter.hbs
@@ -1,1 +1,1 @@
-{{#trim_surrounding_characters "__"}}{{{ underscore rendered_children.name }}}{{/trim_surrounding_characters}}{{#if has_default_value?}} = {{{ rendered_children.default }}}{{/if}}
+{{#trim_surrounding_characters "__"}}{{{ underscore rendered_children.name }}}{{/trim_surrounding_characters}}{{#if has_default_value?}}={{{ rendered_children.default }}}{{/if}}


### PR DESCRIPTION
Formatting changes to Python unittest export.

- No spaces around `=` in named parameters (parameters with a default value) or arguments passed to them. 
    - This is official Python standard and most linters will flag if it's not followed.
    - This change also affects the behave export.

- Use docstring instead of comments for description and tags.
    - Not required by any conventions, but a more Pythonic way to do it.
    - Has the bonus of allowing runtime inspection of tags.
