### PR TITLE
Add support for samples in circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.4.1-node-browsers
+      - image: circleci/ruby:2.3.8-node-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,59 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/ruby:2.4.1-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | \
+              circleci tests split --split-by=timings)"
+
+            bundle exec rspec \
+              --format progress \
+              --format RspecJunitFormatter \
+              --out /tmp/test-results/rspec.xml \
+              --format progress \
+              $TEST_FILES
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,19 @@ jobs:
       - build_and_test:
         output_dir: "2.6"
 
+  install-hiptest-publisher:
+    docker:
+      - image: hiptest/hiptest-publisher-samples
+
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Install hiptest-publisher
+          command: |
+            bundle
+            bundle exec rake install
+
   hps-behat:
     docker:
       - image: hiptest/hiptest-publisher-samples
@@ -80,10 +93,8 @@ jobs:
       - run:
           name: run tests
           command: |
-            bundle
-            rake install
             cd /hiptest-publisher-samples/hps/hps-behat
-            hiptest-publisher -t $SECRET_TOEKN -c behat.conf --without=actionwords
+            hiptest-publisher -t $SECRET_TOKEN -c behat.conf --without=actionwords
             vendor/bin/behat
 
 
@@ -98,4 +109,7 @@ workflows:
 
   run_samples:
     jobs:
-      - hps-behat
+      - install-hiptest-publisher
+      - hps-behat:
+          requires:
+            - install-hiptest-publisher

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,8 @@ commands:
             bundle install
             bundle exec rake install
 
-  regenerate_tests:
-    description: "Regenerate tests with hiptest-publisher"
+  regenerate_and_run_tests:
+    description: "Regenerate tests with hiptest-publisher and run them"
     parameters:
       project_path:
         type: string
@@ -63,7 +63,9 @@ commands:
       config_file:
         type: string
         default: ""
-
+      test_command:
+        type: string
+        default: "echo 'No test command provided'"
     steps:
       - checkout
       - restore_bundler_cache
@@ -73,6 +75,7 @@ commands:
           command: |
             cd /hiptest-publisher-samples/hps/<< parameters.project_path >>
             hiptest-publisher -t $SECRET_TOKEN -c << parameters.config_file >> --without=actionwords
+            << parameters.test_command >>
 
 jobs:
   build-ruby-2_3:
@@ -139,13 +142,10 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - regenerate_tests:
+      - regenerate_and_run_tests:
           project_path: "hps-behat"
           config_file: "behat.conf"
-      - run:
-          name: run tests
-          command: |
-            vendor/bin/behat
+          test_command: "vendor/bin/behat"
 
   hps-behave:
     docker:
@@ -153,13 +153,10 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - regenerate_tests:
+      - regenerate_and_run_tests:
           project_path: "hps-behave"
           config_file: "behave.conf"
-      - run:
-          name: run tests
-          command: |
-            behave
+          test_command: "behave"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - checkout
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,27 +136,26 @@ jobs:
   hps-behat:
     docker:
       - image: hiptest/hiptest-publisher-samples
-
     working_directory: ~/repo
+
     steps:
       - regenerate_tests:
-        project_path: "hps-behat"
-        config_file: "behat.conf"
+          project_path: "hps-behat"
+          config_file: "behat.conf"
       - run:
           name: run tests
           command: |
             vendor/bin/behat
 
-
   hps-behave:
     docker:
       - image: hiptest/hiptest-publisher-samples
-
     working_directory: ~/repo
+
     steps:
       - regenerate_tests:
-        project_path: "hps-behave"
-        config_file: "behave.conf"
+          project_path: "hps-behave"
+          config_file: "behave.conf"
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ commands:
       - run:
           name: Install hiptest-publisher
           command: |
+            bundle install
             bundle exec rake install
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,58 +2,85 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
-jobs:
-  build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/ruby:2.3.8-node-browsers
+version: 2.1
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
-    working_directory: ~/repo
-
+commands:
+  build_and_test:
+    description: "Build and run the tests"
+    parameters:
+      output_dir:
+        type: string
+        default: ""
     steps:
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
 
       - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      # run tests!
       - run:
           name: run tests
           command: |
-            mkdir /tmp/test-results
+            mkdir /tmp/test-results/<< parameters.output_dir >>
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | \
               circleci tests split --split-by=timings)"
 
             bundle exec rspec \
               --format progress \
               --format RspecJunitFormatter \
-              --out /tmp/test-results/rspec.xml \
+              --out /tmp/test-results/<< parameters.output_dir >>/rspec.xml \
               --format progress \
               $TEST_FILES
 
-      # collect reports
       - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+          path: /tmp/test-results/<< parameters.output_dir >>
+
+jobs:
+  build-ruby-2.3:
+    docker:
+      - image: circleci/ruby:2.3.8
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test:
+        output_dir: "2.3"
+
+jobs:
+  build-ruby-2.4:
+    docker:
+      - image: circleci/ruby:2.4.5
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test:
+        output_dir: "2.4"
+
+jobs:
+  build-ruby-2.5:
+    docker:
+      - image: circleci/ruby:2.5.5
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test:
+        output_dir: "2.5"
+
+jobs:
+  build-ruby-2.6:
+    docker:
+      - image: circleci/ruby:2.6.2
+
+    working_directory: ~/repo
+    steps:
+      - build_and_test:
+        output_dir: "2.6"
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-ruby-2.3
+      - build-ruby-2.4
+      - build-ruby-2.5
+      - build-ruby-2.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,3 @@
-# Ruby CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-ruby/ for more details
-#
 version: 2.1
 
 commands:
@@ -37,7 +33,7 @@ commands:
           path: /tmp/test-results/<< parameters.output_dir >>
 
 jobs:
-  build-ruby-2.3:
+  build-ruby-2_3:
     docker:
       - image: circleci/ruby:2.3.8
 
@@ -46,8 +42,7 @@ jobs:
       - build_and_test:
         output_dir: "2.3"
 
-jobs:
-  build-ruby-2.4:
+  build-ruby-2_4:
     docker:
       - image: circleci/ruby:2.4.5
 
@@ -56,8 +51,7 @@ jobs:
       - build_and_test:
         output_dir: "2.4"
 
-jobs:
-  build-ruby-2.5:
+  build-ruby-2_5:
     docker:
       - image: circleci/ruby:2.5.5
 
@@ -66,8 +60,7 @@ jobs:
       - build_and_test:
         output_dir: "2.5"
 
-jobs:
-  build-ruby-2.6:
+  build-ruby-2_6:
     docker:
       - image: circleci/ruby:2.6.2
 
@@ -80,7 +73,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-ruby-2.3
-      - build-ruby-2.4
-      - build-ruby-2.5
-      - build-ruby-2.6
+      - build-ruby-2_3
+      - build-ruby-2_4
+      - build-ruby-2_5
+      - build-ruby-2_6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,18 @@ jobs:
       - build_and_test:
         output_dir: "2.6"
 
+  hps-behat:
+    docker:
+      - image: hiptest/hiptest-publisher-samples
+
+    working_directory: /hiptest-publisher-samples/hps/hps-behat
+    steps:
+      - run:
+          name: run tests
+          command: |
+            vendor/bin/behat -f cucumber_json
+
+
 workflows:
   version: 2
   build:
@@ -77,3 +89,7 @@ workflows:
       - build-ruby-2_4
       - build-ruby-2_5
       - build-ruby-2_6
+
+  run_samples:
+    jobs:
+      - hps-behat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,15 @@ jobs:
       - run:
           name: Install hiptest-publisher
           command: |
-            bundle install && bundle clean
-            bundle exec rake install
+            bundle install && bundle clean --force
       - save_cache:
           paths:
             - ~/.bundle
           key: v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install hiptest-publisher
+          command: |
+            bundle exec rake install
 
 
   hps-behat:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,26 @@ commands:
             bundle install
             bundle exec rake install
 
+  regenerate_tests:
+    description: "Regenerate tests with hiptest-publisher"
+    parameters:
+      project_path:
+        type: string
+        default: ""
+      config_file:
+        type: string
+        default: ""
+
+    steps:
+      - checkout
+      - restore_bundler_cache
+      - install_hiptest_publisher
+      - run:
+          name: Generate tests
+          command: |
+            cd /hiptest-publisher-samples/hps/<< parameters.project_path >>
+            hiptest-publisher -t $SECRET_TOKEN -c << parameters.config_file >> --without=actionwords
+
 jobs:
   build-ruby-2_3:
     docker:
@@ -118,18 +138,29 @@ jobs:
       - image: hiptest/hiptest-publisher-samples
 
     working_directory: ~/repo
-
     steps:
-      - checkout
-      - restore_bundler_cache
-      - install_hiptest_publisher
+      - regenerate_tests:
+        project_path: "hps-behat"
+        config_file: "behat.conf"
       - run:
           name: run tests
           command: |
-            cd /hiptest-publisher-samples/hps/hps-behat
-            hiptest-publisher -t $SECRET_TOKEN -c behat.conf --without=actionwords
             vendor/bin/behat
 
+
+  hps-behave:
+    docker:
+      - image: hiptest/hiptest-publisher-samples
+
+    working_directory: ~/repo
+    steps:
+      - regenerate_tests:
+        project_path: "hps-behave"
+        config_file: "behave.conf"
+      - run:
+          name: run tests
+          command: |
+            behave
 
 workflows:
   version: 2
@@ -144,5 +175,8 @@ workflows:
     jobs:
       - install-hiptest-publisher
       - hps-behat:
+          requires:
+            - install-hiptest-publisher
+      - hps-behave:
           requires:
             - install-hiptest-publisher

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,22 +73,27 @@ jobs:
     docker:
       - image: hiptest/hiptest-publisher-samples
 
-    working_directory: /hiptest-publisher-samples/hps/hps-behat
+    working_directory: ~/repo
+
     steps:
       - run:
           name: run tests
           command: |
-            vendor/bin/behat -f cucumber_json
+            bundle
+            rake install
+            cd /hiptest-publisher-samples/hps/hps-behat
+            hiptest-publisher -t $SECRET_TOEKN -c behat.conf --without=actionwords
+            vendor/bin/behat
 
 
 workflows:
   version: 2
-  build:
-    jobs:
-      - build-ruby-2_3
-      - build-ruby-2_4
-      - build-ruby-2_5
-      - build-ruby-2_6
+  # build:
+  #   jobs:
+  #     - build-ruby-2_3
+  #     - build-ruby-2_4
+  #     - build-ruby-2_5
+  #     - build-ruby-2_6
 
   run_samples:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,10 @@
 version: 2.1
 
 commands:
+  #############################################################################
+  #                     Hiptest publisher CI jobs                             #
+  #############################################################################
+
   build_and_test:
     description: "Build and run the tests"
     parameters:
@@ -9,7 +13,6 @@ commands:
         default: ""
     steps:
       - checkout
-
       - run:
           name: install dependencies
           command: |
@@ -69,18 +72,33 @@ jobs:
       - build_and_test:
         output_dir: "2.6"
 
+  #############################################################################
+  #                   Hiptest publisher samples jobs                          #
+  #############################################################################
+
   install-hiptest-publisher:
     docker:
       - image: hiptest/hiptest-publisher-samples
 
     working_directory: ~/repo
     steps:
+      - restore_cache:
+          keys:
+            # when lock file changes, use increasingly general patterns to restore cache
+            - v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v1-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v1-gem-cache-{{ arch }}-
       - checkout
       - run:
           name: Install hiptest-publisher
           command: |
-            bundle
+            bundle install && bundle clean
             bundle exec rake install
+      - save_cache:
+          paths:
+            - ~/.bundle
+          key: v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+
 
   hps-behat:
     docker:
@@ -90,6 +108,11 @@ jobs:
 
     steps:
       - checkout
+      - run:
+          name: Install hiptest-publisher
+          command: |
+            bundle install && bundle clean
+            bundle exec rake install
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,24 @@ commands:
       - store_test_results:
           path: /tmp/test-results/<< parameters.output_dir >>
 
+  restore_bundler_cache:
+    description: "Restore cached gems"
+    steps:
+      - restore_cache:
+          keys:
+            # when lock file changes, use increasingly general patterns to restore cache
+            - v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v1-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v1-gem-cache-{{ arch }}-
+
+  install_hiptest_publisher:
+    description: "Install Hiptest publisher"
+    steps:
+      - run:
+          name: Install hiptest-publisher
+          command: |
+            bundle exec rake install
+
 jobs:
   build-ruby-2_3:
     docker:
@@ -82,12 +100,7 @@ jobs:
 
     working_directory: ~/repo
     steps:
-      - restore_cache:
-          keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            - v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - v1-gem-cache-{{ arch }}-{{ .Branch }}-
-            - v1-gem-cache-{{ arch }}-
+      - restore_bundler_cache
       - checkout
       - run:
           name: Install hiptest-publisher
@@ -97,11 +110,7 @@ jobs:
           paths:
             - ~/.bundle
           key: v1-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: Install hiptest-publisher
-          command: |
-            bundle exec rake install
-
+      - install_hiptest_publisher
 
   hps-behat:
     docker:
@@ -110,12 +119,9 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - restore_bundler_cache
       - checkout
-      - run:
-          name: Install hiptest-publisher
-          command: |
-            bundle install && bundle clean
-            bundle exec rake install
+      - install_hiptest_publisher
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
 
     working_directory: ~/repo
     steps:
-      - restore_bundler_cache
       - checkout
+      - restore_bundler_cache
       - run:
           name: Install hiptest-publisher
           command: |
@@ -119,8 +119,8 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - restore_bundler_cache
       - checkout
+      - restore_bundler_cache
       - install_hiptest_publisher
       - run:
           name: run tests

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@
 
 # Ignore gem
 /*.gem
-/hps-cucumber-groovy/target/
 
 # Ignore Mac files
 .DS_Store
+
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ end
 
 group :test do
   gem 'webmock'
+  gem 'rspec_junit_formatter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     ruby-handlebars (0.1.1)
       parslet (~> 1.6, >= 1.6.2)
     ruby_version (1.0.1)
@@ -179,6 +181,7 @@ DEPENDENCIES
   pry-byebug (~> 3)
   rspec (~> 3.3)
   rspec-mocks (~> 3.3)
+  rspec_junit_formatter
   ruby-handlebars (~> 0.1)
   ruby_version (~> 1)
   webmock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 HipTest Publisher
 ==============
 
+[![CircleCI](https://circleci.com/gh/hiptest/hiptest-publisher.svg?style=svg)](https://circleci.com/gh/hiptest/hiptest-publisher)
 [![Build Status Linux](https://travis-ci.org/hiptest/hiptest-publisher.svg?branch=master)](https://travis-ci.org/hiptest/hiptest-publisher)
 [![Build Status Windows](https://ci.appveyor.com/api/projects/status/ciahcci0ayr1oihr/branch/master?svg=true)](https://ci.appveyor.com/project/hiptest/hiptest-publisher)
 [![Gem Version](https://badge.fury.io/rb/hiptest-publisher.svg)](http://badge.fury.io/rb/hiptest-publisher)

--- a/lib/hiptest-publisher/client.rb
+++ b/lib/hiptest-publisher/client.rb
@@ -188,6 +188,10 @@ module Hiptest
     end
 
     def find_proxy_uri(address, port)
+      puts "----------------------------------------------------"
+      puts "Found HTTP_PROXY: #{ENV['http_proxy']}"
+      puts "----------------------------------------------------"
+
       URI::HTTP.new(
         "http", nil, address, port, nil, nil, nil, nil, nil
       ).find_proxy

--- a/lib/hiptest-publisher/client.rb
+++ b/lib/hiptest-publisher/client.rb
@@ -188,10 +188,6 @@ module Hiptest
     end
 
     def find_proxy_uri(address, port)
-      puts "----------------------------------------------------"
-      puts "Found HTTP_PROXY: #{ENV['http_proxy']}"
-      puts "----------------------------------------------------"
-
       URI::HTTP.new(
         "http", nil, address, port, nil, nil, nil, nil, nil
       ).find_proxy


### PR DESCRIPTION
Currently supported samples:

[x] hps-behat
[x] hps-behave
[ ] hps-csharp-nunit
[ ] hps-cucumber-groovy
[ ] hps-cucumber-java
[ ] hps-cucumber-javascript
[ ] hps-cucumber-ruby
[ ] hps-cucumber-typescript
[ ] hps-groovy-spock
[ ] hps-java-junit
[ ] hps-java-testng
[ ] hps-javascript-jasmine
[ ] hps-javascript-mocha
[ ] hps-javascript-qunit
[ ] hps-jbehave
[ ] hps-php-phpunit
[ ] hps-protractor
[ ] hps-python-unittest
[ ] hps-robotframework
[ ] hps-ruby-minitest
[ ] hps-ruby-rspec
[ ] hps-specflow
