### PR TITLE
Make rake install/release work on ruby 2.6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ HipTest Publisher Changelog
 [Unreleased]
 ------------
 
+ - Make `rake install` work with ruby 2.6
  - `--parameter-delimiter` option now accepts empty string
 
 [1.28.0]

--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,23 @@ Juwelier::Tasks.new do |gem|
 end
 Juwelier::RubygemsDotOrgTasks.new
 
+# Backport PR flajann2/juwelier#9 for ruby 2.6
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
+  require 'juwelier/gemspec_helper'
+  class Juwelier
+    class GemSpecHelper
+      def parse
+        data = to_ruby
+        parsed_gemspec = nil
+        Thread.new { parsed_gemspec = eval("$SAFE = 1\n#{data}", binding, path) }.join
+        # Need to reset $SAFE to 0 as it is process global since ruby 2.6
+        $SAFE = 0 if $SAFE == 1
+        parsed_gemspec
+      end
+    end
+  end
+end
+
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'

--- a/bin/travis_script.sh
+++ b/bin/travis_script.sh
@@ -1,7 +1,7 @@
 echo "Running local gem"
 bundle exec ruby -I lib bin/hiptest-publisher --help
 
-gem install hiptest-publisher
+rake install
 echo "== Running hiptest-publisher --help"
 hiptest-publisher --help
 


### PR DESCRIPTION
Backports the fix in https://github.com/flajann2/juwelier/pull/9 with
monkey patching.

Also use `rake install` instead of `gem install hiptest-publisher` in the travis script.