### PR TITLE
Simplify command line interface

### DIFF
--- a/hp/Gemfile
+++ b/hp/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/hp/Gemfile.lock
+++ b/hp/Gemfile.lock
@@ -1,0 +1,62 @@
+PATH
+  remote: .
+  specs:
+    hp (0.0.1)
+      gli (= 2.19.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aruba (0.14.11)
+      childprocess (>= 0.6.3, < 3.0.0)
+      contracts (~> 0.9)
+      cucumber (>= 1.3.19)
+      ffi (~> 1.9)
+      rspec-expectations (>= 2.99)
+      thor (~> 0.19)
+    backports (3.15.0)
+    builder (3.2.3)
+    childprocess (2.0.0)
+      rake (< 13.0)
+    contracts (0.16.0)
+    cucumber (3.1.2)
+      builder (>= 2.1.2)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.3)
+    ffi (1.11.1)
+    gherkin (5.1.0)
+    gli (2.19.0)
+    multi_json (1.13.1)
+    multi_test (0.1.2)
+    rake (12.3.3)
+    rdoc (6.2.0)
+    rspec-expectations (3.8.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
+    thor (0.20.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aruba
+  hp!
+  rake
+  rdoc
+
+BUNDLED WITH
+   1.17.2

--- a/hp/README.rdoc
+++ b/hp/README.rdoc
@@ -1,0 +1,6 @@
+= hp
+
+Describe your project here
+
+:include:hp.rdoc
+

--- a/hp/Rakefile
+++ b/hp/Rakefile
@@ -1,0 +1,44 @@
+require 'rake/clean'
+require 'rubygems'
+require 'rubygems/package_task'
+require 'rdoc/task'
+require 'cucumber'
+require 'cucumber/rake/task'
+Rake::RDocTask.new do |rd|
+  rd.main = "README.rdoc"
+  rd.rdoc_files.include("README.rdoc","lib/**/*.rb","bin/**/*")
+  rd.title = 'Your application title'
+end
+
+spec = eval(File.read('hp.gemspec'))
+
+Gem::PackageTask.new(spec) do |pkg|
+end
+CUKE_RESULTS = 'results.html'
+CLEAN << CUKE_RESULTS
+desc 'Run features'
+Cucumber::Rake::Task.new(:features) do |t|
+  opts = "features --format html -o #{CUKE_RESULTS} --format progress -x"
+  opts += " --tags #{ENV['TAGS']}" if ENV['TAGS']
+  t.cucumber_opts =  opts
+  t.fork = false
+end
+
+desc 'Run features tagged as work-in-progress (@wip)'
+Cucumber::Rake::Task.new('features:wip') do |t|
+  tag_opts = ' --tags ~@pending'
+  tag_opts = ' --tags @wip'
+  t.cucumber_opts = "features --format html -o #{CUKE_RESULTS} --format pretty -x -s#{tag_opts}"
+  t.fork = false
+end
+
+task :cucumber => :features
+task 'cucumber:wip' => 'features:wip'
+task :wip => 'features:wip'
+require 'rake/testtask'
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*_test.rb']
+end
+
+task :default => [:test,:features]

--- a/hp/bin/hiptest-cli
+++ b/hp/bin/hiptest-cli
@@ -1,0 +1,256 @@
+#!/usr/bin/env ruby
+require 'gli'
+begin # XXX: Remove this begin/rescue before distributing your app
+require 'hp'
+rescue LoadError
+  STDERR.puts "In development, you need to use `bundle exec bin/hp` to run your app"
+  STDERR.puts "At install-time, RubyGems will make sure lib, etc. are in the load path"
+  STDERR.puts "Feel free to remove this message from bin/hp now"
+  exit 64
+end
+
+class App
+  extend GLI::App
+
+  program_desc 'Translate your Hiptest examples in executable code and integrate with any CI tool'
+  sort_help :manually
+
+  version Hp::VERSION
+  desc 'Check if a more recent version exists'
+  switch :'check-version', negatable: false
+
+  subcommand_option_handling :normal
+  arguments :strict
+
+  desc 'Config file'
+  arg_name 'PATH'
+  flag :c, :config
+
+  desc 'Secret token'
+  arg_name 'TOKEN'
+  flag :t, :token
+
+  desc 'Output directory'
+  arg_name 'PATH'
+  flag :o, :'output-directory', default_value: '.'
+
+  desc 'URL of the site'
+  arg_name 'TOKEN'
+  flag :s, :site, default_value: 'https://hiptest.com'
+
+  desc 'http-proxy to use'
+  arg_name 'PROXY_URL'
+  flag :'http-proxy'
+
+  desc 'XML file to use instead of fetching it from HipTest'
+  arg_name 'PROJECT.xml'
+  flag :x, :'xml-file'
+
+  desc 'Force overwrite of any file'
+  switch :force, default_value: false, negatable: false
+
+  desc 'Use verbose mode'
+  switch :v, :verbose, default_value: false, negatable: false
+
+
+  desc 'Generate executable code'
+  command :publish do |c|
+    c.desc 'Target language'
+    c.arg_name 'LANG'
+    c.flag :l, :language, default_value: 'ruby'
+
+    c.desc 'Target framework'
+    c.arg_name 'FRAMEWORK'
+    c.flag :f, :framework
+
+    c.desc 'Path to overriden templates'
+    c.arg_name 'PATH'
+    c.flag :'overriden-templates'
+
+    c.desc 'ID of the test run to generate code from'
+    c.arg_name 'ID'
+    c.flag :'test-run-id'
+
+    c.desc 'Name of the test run to generate code from'
+    c.arg_name 'CI'
+    c.flag :'test-run-name'
+
+    c.desc "Filename pattern (containing %s)"
+    c.arg_name 'PATTERN'
+    c.flag :'filename-pattern'
+
+    c.desc "Keep the same name as in HipTest for the test files (note: may cause encoding issues)"
+    c.switch :'keep-filenames', negatable: false
+
+    c.desc "Keep the same name as in HipTest for the folders (note: may cause encoding issues)"
+    c.switch :'keep-foldernames', negatable: false
+
+    c.desc "Select categories of data to export (tests, actionwords ...)"
+    c.arg_name 'CATEGORIES'
+    c.flag :only
+
+    c.desc "Select categories of data to exclude (tests, actionwords ...)"
+    c.arg_name 'CATEGORIES'
+    c.flag :without
+
+    c.desc "Select actionword library to export"
+    c.arg_name 'LIBRARY_NAME'
+    c.flag :'library-name'
+
+    c.desc "Export with the same hierarchy than in Hiptest"
+    c.switch :'with-folders', negatable: false
+
+    c.desc "Export folders without tests"
+    c.switch :'empty-folders', negatable: false
+
+    c.desc "Export each scenario in a separate file"
+    c.switch :'split-scenarios', negatable: false
+
+    c.desc "Select order in which actionwords are generated"
+    c.arg_name 'id,order,alpha'
+    c.flag :sort
+
+    c.desc "Export scenario UIDs in test files"
+    c.switch :uids
+
+    c.desc "Add folder tags to scenarios"
+    c.switch :'parent-folder-tags'
+
+    c.desc "Parameter delimiter (for Gherkin based export only)"
+    c.arg_name "DELIMITED"
+    c.flag :'parameter-delimiter'
+
+    c.desc "Export dataset name when creating feature files (note: available only for Gherkin-based exports)"
+    c.switch :'with-dataset-names', negatable: false
+
+    c.desc "Meta-data to use in exports"
+    c.arg_name "META"
+    c.flag :meta
+
+    c.command :filter do |filter|
+      filter.desc "Filter on folder ids (use commas to separate ids when fetching multiple folders)"
+      filter.arg_name "IDS"
+      filter.flag :'folder_ids'
+
+      filter.desc "Used in conjunction with filter-on-folder-ids or filter-on-folder-name: only exports those folders, not their children"
+      filter.switch :'not-recursive', negatable: false
+
+      filter.desc "Filter on folder name (only one name is accepted)"
+      filter.arg_name "NAME"
+      filter.flag :'folder_name'
+
+      filter.desc "Filter on scenario ids (use commas to separate ids when fetching multiple scenarios)"
+      filter.arg_name "IDS"
+      filter.flag :'scenario_ids'
+
+      filter.desc "Filter on scenario name (only one name is accepted)"
+      filter.arg_name "NAME"
+      filter.flag :'scenario_name'
+
+      filter.desc "Filter on test status in last build (use in conjunction with a test run)"
+      filter.arg_name "STATUS"
+      filter.flag :'status'
+
+      filter.desc "Filter on scenarios and folder tags (use commas to separate tags when using multiple tags)"
+      filter.arg_name "TAGS"
+      filter.flag :'tags'
+
+      filter.action do |global_options, options, args|
+        puts "Options: #{options}"
+        puts "Generate filter ran"
+      end
+    end
+
+    c.action do |global_options,options,args|
+
+      # Your command logic here
+
+      # If you have any errors, just raise them
+      # raise "that command made no sense"
+
+      puts "generate command ran"
+    end
+  end
+
+  desc 'Scale your action words library'
+  command :scale do |c|
+    c.desc 'Output changes in JSON format'
+    c.switch :'json', negatable: false
+
+    c.desc 'Show action words created'
+    c.switch :created, negatable: false
+
+    c.desc 'Show action words deleted'
+    c.switch :deleted, negatable: false
+
+    c.desc 'Show action words renamed'
+    c.switch :renamed, negatable: false
+
+    c.desc 'Show action words which signature changed'
+    c.switch :'signature-changed', negatable: false
+
+    c.desc 'Show action words which definition changed'
+    c.switch :'definition-changed', negatable: false
+
+    c.desc 'Update signature file'
+    c.switch :signature, negatable: false
+
+    c.action do |global_options, options, args|
+      puts "scale command ran"
+    end
+  end
+
+  desc 'Share your test execution results on Hiptest'
+  # Option.new(nil, 'global-failure-on-missing-reports', false, nil, I18n.t('options.global_failure_on_missing_reports'), :global_failure_on_missing_reports),
+  command :share do |c|
+    c.desc 'Test report file(s) to push'
+    c.arg_name 'FILE.tap'
+    c.flag :f, :file, :files, required: true
+
+    c.desc 'Format of the report file(s)'
+    c.arg_name 'tap'
+    c.flag :'push-format', default_value: 'tap', must_match: ['cucumber-json', 'junit', 'nunit', 'robot', 'tap']
+
+    c.desc 'ID of the test run where results will be shown'
+    c.arg_name '1234'
+    c.flag :id, :'test-run-id'
+
+    c.desc 'Name of the test run where results will be shown'
+    c.arg_name 'CI'
+    c.flag :name, :'test-run-name'
+
+    c.desc 'Execution environment where tests were executed'
+    c.arg_name 'ENV'
+    c.flag :e, :'execution-environment'
+
+    c.desc 'Mark tests as failed if no reports are present'
+    c.switch :'global-failure-on-missing-reports'
+
+    c.action do |global_options, options, args|
+      puts "share command ran"
+    end
+  end
+
+  pre do |global,command,options,args|
+    # Pre logic here
+    # Return true to proceed; false to abort and not call the
+    # chosen command
+    # Use skips_pre before a command to skip this block
+    # on that command only
+    true
+  end
+
+  post do |global,command,options,args|
+    # Post logic here
+    # Use skips_post before a command to skip this
+    # block on that command only
+  end
+
+  on_error do |exception|
+    # Error logic here
+    # return false to skip default error handling
+    true
+  end
+end
+
+exit App.run(ARGV)

--- a/hp/features/hp.feature
+++ b/hp/features/hp.feature
@@ -1,0 +1,8 @@
+Feature: My bootstrapped app kinda works
+  In order to get going on coding my awesome app
+  I want to have aruba and cucumber setup
+  So I don't have to do it myself
+
+  Scenario: App just runs
+    When I get help for "hp"
+    Then the exit status should be 0

--- a/hp/features/step_definitions/hp_steps.rb
+++ b/hp/features/step_definitions/hp_steps.rb
@@ -1,0 +1,6 @@
+When /^I get help for "([^"]*)"$/ do |app_name|
+  @app_name = app_name
+  step %(I run `#{app_name} help`)
+end
+
+# Add more step definitions here

--- a/hp/features/support/env.rb
+++ b/hp/features/support/env.rb
@@ -1,0 +1,15 @@
+require 'aruba/cucumber'
+
+ENV['PATH'] = "#{File.expand_path(File.dirname(__FILE__) + '/../../bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
+LIB_DIR = File.join(File.expand_path(File.dirname(__FILE__)),'..','..','lib')
+
+Before do
+  # Using "announce" causes massive warnings on 1.9.2
+  @puts = true
+  @original_rubylib = ENV['RUBYLIB']
+  ENV['RUBYLIB'] = LIB_DIR + File::PATH_SEPARATOR + ENV['RUBYLIB'].to_s
+end
+
+After do
+  ENV['RUBYLIB'] = @original_rubylib
+end

--- a/hp/hp.gemspec
+++ b/hp/hp.gemspec
@@ -1,0 +1,22 @@
+# Ensure we require the local version and not one we might have installed already
+require File.join([File.dirname(__FILE__),'lib','hp','version.rb'])
+spec = Gem::Specification.new do |s|
+  s.name = 'hp'
+  s.version = Hp::VERSION
+  s.author = 'Your Name Here'
+  s.email = 'your@email.address.com'
+  s.homepage = 'http://your.website.com'
+  s.platform = Gem::Platform::RUBY
+  s.summary = 'A description of your project'
+  s.files = `git ls-files`.split("
+")
+  s.require_paths << 'lib'
+  s.extra_rdoc_files = ['README.rdoc','hp.rdoc']
+  s.rdoc_options << '--title' << 'hp' << '--main' << 'README.rdoc' << '-ri'
+  s.bindir = 'bin'
+  s.executables << 'hiptest-cli'
+  s.add_development_dependency('rake')
+  s.add_development_dependency('rdoc')
+  s.add_development_dependency('aruba')
+  s.add_runtime_dependency('gli','2.19.0')
+end

--- a/hp/hp.rdoc
+++ b/hp/hp.rdoc
@@ -1,0 +1,5 @@
+= hp
+
+Generate this with
+    hp _doc
+After you have described your command line interface

--- a/hp/lib/hp.rb
+++ b/hp/lib/hp.rb
@@ -1,0 +1,4 @@
+require 'hp/version.rb'
+
+# Add requires for other files you add to your project here, so
+# you just need to require this one file in your bin file

--- a/hp/lib/hp/version.rb
+++ b/hp/lib/hp/version.rb
@@ -1,0 +1,3 @@
+module Hp
+  VERSION = '0.0.1'
+end

--- a/hp/test/default_test.rb
+++ b/hp/test/default_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class DefaultTest < Test::Unit::TestCase
+
+  def setup
+  end
+
+  def teardown
+  end
+
+  def test_the_truth
+    assert true
+  end
+end

--- a/hp/test/test_helper.rb
+++ b/hp/test/test_helper.rb
@@ -1,0 +1,9 @@
+require 'test/unit'
+
+# Add test libraries you want to use here, e.g. mocha
+
+class Test::Unit::TestCase
+
+  # Add global extensions to the test case class here
+
+end


### PR DESCRIPTION
## Motivation and description of the pull request

The command-line interface is currently pretty hard to use (there's currently 61 available options and filters available and ``hiptest-publisher --help``is pretty hard to read/understand).

Another issue is that there is in fact two/three tools built in ``hiptest-publisher``:
 - code generation
 - upgrade of action words library
 - pushing results back to HipTest

The idea behind this PR is to see what could be doable to make this better. I've been trying [GLI](https://github.com/davetron5000/gli) to create sub-commands in order to make this simpler.
I also renamed the command line ``hiptest-cli``as we do more than publishing.

It looks like this now:

```shell
bundle exec hiptest-cli
NAME
    hiptest-cli - Translate your Hiptest examples in executable code and integrate with any CI tool

SYNOPSIS
    hiptest-cli [global options] command [command options] [arguments...]

VERSION
    0.0.1

GLOBAL OPTIONS
    -c, --config=PATH           - Config file (default: none)
    -t, --token=TOKEN           - Secret token (default: none)
    -o, --output-directory=PATH - Output directory (default: .)
    -s, --site=TOKEN            - URL of the site (default: https://hiptest.com)
    --http-proxy=PROXY_URL      - http-proxy to use (default: none)
    -x, --xml-file=PROJECT.xml  - XML file to use instead of fetching it from HipTest (default: none)
    --version                   - Display the program version
    --check-version             - Check if a more recent version exists
    --force                     - Force overwrite of any file
    -v, --verbose               - Use verbose mode
    --help                      - Show this message

COMMANDS
    help    - Shows a list of commands or help for one command
    publish - Generate executable code
    scale   - Scale your action words library
    share   - Share your test execution results on Hiptest
```

And each sub-command as its own parameters:

### publishing

The sub-command is named ``publish``. It still has a load of options (but I removed some like ``test-only``, `àctionwords-only``and ``leafless``which are deprecated and/or buggy).

```shell
bundle exec hiptest-cli publish --help
NAME
    publish - Generate executable code

SYNOPSIS
    hiptest-cli [global options] publish [command options] 
    hiptest-cli [global options] publish [command options] filter [--folder_ids IDS] [--folder_name NAME] [--not-recursive] [--scenario_ids IDS] [--scenario_name NAME] [--status STATUS] [--tags TAGS]

COMMAND OPTIONS
    -l, --language=LANG             - Target language (default: ruby)
    -f, --framework=FRAMEWORK       - Target framework (default: none)
    --overriden-templates=PATH      - Path to overriden templates (default: none)
    --test-run-id=ID                - ID of the test run to generate code from (default: none)
    --test-run-name=CI              - Name of the test run to generate code from (default: none)
    --filename-pattern=PATTERN      - Filename pattern (containing %s) (default: none)
    --only=CATEGORIES               - Select categories of data to export (tests, actionwords ...) (default: none)
    --without=CATEGORIES            - Select categories of data to exclude (tests, actionwords ...) (default: none)
    --library-name=LIBRARY_NAME     - Select actionword library to export (default: none)
    --sort=id,order,alpha           - Select order in which actionwords are generated (default: none)
    --parameter-delimiter=DELIMITED - Parameter delimiter (for Gherkin based export only) (default: none)
    --meta=META                     - Meta-data to use in exports (default: none)
    --keep-filenames                - Keep the same name as in HipTest for the test files (note: may cause encoding issues)
    --keep-foldernames              - Keep the same name as in HipTest for the folders (note: may cause encoding issues)
    --with-folders                  - Export with the same hierarchy than in Hiptest
    --empty-folders                 - Export folders without tests
    --split-scenarios               - Export each scenario in a separate file
    --[no-]uids                     - Export scenario UIDs in test files
    --[no-]parent-folder-tags       - Add folder tags to scenarios
    --with-dataset-names            - Export dataset name when creating feature files (note: available only for Gherkin-based exports)

COMMANDS
    <default> - 
    filter    - Filter exported data
```

**Note:** filter is a sub-command here. But the tests will be published too.

```shell
bundle exec hiptest-cli publish filter --help
NAME
    filter - Filter exported data

SYNOPSIS
    hiptest-cli [global options] publish filter [command options] 

COMMAND OPTIONS
    --folder_ids=IDS     - Filter on folder ids (use commas to separate ids when fetching multiple folders) (default: none)
    --folder_name=NAME   - Filter on folder name (only one name is accepted) (default: none)
    --scenario_ids=IDS   - Filter on scenario ids (use commas to separate ids when fetching multiple scenarios) (default: none)
    --scenario_name=NAME - Filter on scenario name (only one name is accepted) (default: none)
    --status=STATUS      - Filter on test status in last build (use in conjunction with a test run) (default: none)
    --tags=TAGS          - Filter on scenarios and folder tags (use commas to separate tags when using multiple tags) (default: none)
    --not-recursive      - Used in conjunction with filter-on-folder-ids or filter-on-folder-name: only exports those folders, not their children

```

### upgrading action words library

The sub-command is named ``scale``which is an awful name :/ Any better proposition is welcome :)

```shell
bundle exec hiptest-cli scale --help         
NAME
    scale - Scale your action words library

SYNOPSIS
    hiptest-cli [global options] scale [command options] 

COMMAND OPTIONS
    --json               - Output changes in JSON format
    --created            - Show action words created
    --deleted            - Show action words deleted
    --renamed            - Show action words renamed
    --signature-changed  - Show action words which signature changed
    --definition-changed - Show action words which definition changed
    --signature          - Update signature file
```

### pushing results

The sub-command has been named ``share`` as ``--push``may not be that self-explanatory. 

```shell
bundle exec hiptest-cli share --help
NAME
    share - Share your test execution results on Hiptest

SYNOPSIS
    hiptest-cli [global options] share [command options] 

COMMAND OPTIONS
    -f, --file, --files=FILE.tap        - Test report file(s) to push (required, default: none)
    --push-format=tap                   - Format of the report file(s) (default: tap)
    --id, --test-run-id=1234            - ID of the test run where results will be shown (default: none)
    --name, --test-run-name=CI          - Name of the test run where results will be shown (default: none)
    -e, --execution-environment=ENV     - Execution environment where tests were executed (default: none)
    --global-failure-on-missing-reports - Mark tests as failed if no reports are present```

## TODO

Discuss :D

### Ease migration

Also one thing I'd like is to have hiptest-publisher 2.0 supporting only this new system, but the next releases in the 1.x should help users in the migration.

Something like this:
```shell
hiptest-publisher -c config-file --test-run-id=12

DEPRECATION: hiptest-publisher executable will be deprecated, use this command line instead:
hiptest-cli -c config-file publish --test-run-id=12

hiptest-publisher -c config-file --show-actionwords-diff

DEPRECATION: hiptest-publisher executable will be deprecated, use this command line instead:
hiptest-cli -c config-file scale

hiptest-publisher -c config-file --test-run-id=12 --push=report.xml --push-format=junit

DEPRECATION: hiptest-publisher executable will be deprecated, use this command line instead:
hiptest-cli -c config-file share--test-run-id=12 --format=junit --file=report.xml
```

### Ease migration to new config file format

GLI support config files based on the interface in a Yaml format, we should have something like:

```shell
hiptest-publisher -c config-file --generate-hiptest-cli-config
site: https://hiptest.com
publish:
  language: java
  overriden_templates: "./templates"
share:
  test_run_id: 12
  push_format: junta
```

### Find a better wording

Most of the options are not self-explanatory :/ at least the help for them should be easier to understand. 

## Type of change

- [X] Breaking change (loosing support of old ruby versions, incompatibility with previous templates or config files)
- [X] New functionnality
- [ ] Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added