### PR TITLE
Stop adding test uids by default, add them when test run is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ HipTest Publisher Changelog
 [Unreleased]
 ------------
 
- - Nothing changed yet
+ - No test uids in datatables by default for feature files, add them when test run is used
 
 [2.2.0]
 -------

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
     test_run_name: Export data from a test run identified by its name
     tests_only: "(deprecated) alias for --only=tests"
     token: Secret token (available in your project settings)
-    uids: 'Export UIDs (note: can be disabled only for Gherkin-based exports, may cause issue when pushing results back)'
+    uids: 'Export UIDs for Gherkin-based exports (note: disabled by default, enabled when specifying test run, disabling it may cause issue when pushing results back into test run)'
     verbose: Run verbosely
     with_dataset_names: 'Export dataset name when creating feature files (note: available only for Gherkin-based exports)'
     with_folders: Use folders hierarchy to export files in respective directories

--- a/lib/hiptest-publisher/options_parser.rb
+++ b/lib/hiptest-publisher/options_parser.rb
@@ -114,6 +114,10 @@ class CliOptions < OpenStruct
     option_present?(test_run_name)
   end
 
+  def test_run?
+    test_run_id? || test_run_name?
+  end
+
   def language_framework
     if framework.empty?
       language
@@ -132,10 +136,15 @@ class CliOptions < OpenStruct
       "--#{key.to_s.gsub('_', '-')}=#{self[key]}"
     end.compact
 
-    return "hiptest-publisher #{args.join(' ')}".strip
+    "hiptest-publisher #{args.join(' ')}".strip
+  end
+
+  def uids?
+    __cli_args.include?(:uids) || __config_args.include?(:uids)
   end
 
   def normalize!(reporter = nil)
+    self.uids = true if test_run? && !uids?
     self.no_uids = !uids # silent normalization
     modified_options = self.clone
     if actionwords_only
@@ -249,7 +258,7 @@ class OptionsParser
       Option.new(nil, 'push-format=tap', 'tap', String, I18n.t('options.push_format'), :push_format),
       Option.new(nil, 'execution-environment=NAME', '', String, I18n.t('options.execution_environment'), :execution_environment),
       Option.new(nil, 'sort=[id,order,alpha]', 'order', String, I18n.t('options.sort'), :sort),
-      Option.new(nil, '[no-]uids', true, nil, I18n.t('options.uids'), :uids),
+      Option.new(nil, '[no-]uids', false, nil, I18n.t('options.uids'), :uids),
       Option.new(nil, '[no-]parent-folder-tags', true, nil, I18n.t('options.parent_folder_tags'), :parent_folder_tags),
       Option.new(nil, 'parameter-delimiter=DELIMITER', '"', EmptiableString, I18n.t('options.parameter_delimiter'), :parameter_delimiter),
       Option.new(nil, 'with-dataset-names', false, nil, I18n.t('options.with_dataset_names'), :with_dataset_names),

--- a/lib/hiptest-publisher/options_parser.rb
+++ b/lib/hiptest-publisher/options_parser.rb
@@ -139,12 +139,12 @@ class CliOptions < OpenStruct
     "hiptest-publisher #{args.join(' ')}".strip
   end
 
-  def uids?
-    __cli_args.include?(:uids) || __config_args.include?(:uids)
+  def uids_not_set_yet?
+    !__cli_args.include?(:uids) && !__config_args.include?(:uids)
   end
 
   def normalize!(reporter = nil)
-    self.uids = true if test_run? && !uids?
+    self.uids = true if test_run? && uids_not_set_yet?
     self.no_uids = !uids # silent normalization
     modified_options = self.clone
     if actionwords_only

--- a/lib/templates/groovy/_scenario.hbs
+++ b/lib/templates/groovy/_scenario.hbs
@@ -1,5 +1,5 @@
 {{#if has_datasets?}}
-@Unroll("{{{ escape_double_quotes rendered_children.name }}} #hiptestUid")
+@Unroll("{{{ escape_double_quotes rendered_children.name }}}{{#if context.uids}} #hiptestUid{{/if}}")
 {{/if}}def "{{{ escape_double_quotes rendered_children.name }}}{{#if rendered_children.uid}} (uid:{{{  rendered_children.uid}}}){{/if}}"() {{#curly}}{{#indent}}{{> desc}}{{#unless has_annotations?}}{{#unless is_empty?}}
 expect:{{/unless}}{{/unless}}
 {{> steps}}{{#if has_datasets?}}

--- a/spec/options_parser_spec.rb
+++ b/spec/options_parser_spec.rb
@@ -104,6 +104,39 @@ describe OptionParser do
     options = OptionsParser.parse(["--no-uids"], NullReporter.new)
     expect(options.uids).to be(false)
   end
+
+  it "implies --uids if --test-run-name or test-run-id is set" do
+    options = OptionsParser.parse(["--test-run-name", "hello"], NullReporter.new)
+    expect(options.uids).to be(true)
+    expect(options.no_uids).to be(false)
+
+    options = OptionsParser.parse(["--test-run-id", "1234"], NullReporter.new)
+    expect(options.uids).to be(true)
+    expect(options.no_uids).to be(false)
+
+    options = OptionsParser.parse(["--with-folders"], NullReporter.new)
+    expect(options.uids).to be(false)
+    expect(options.no_uids).to be(true)
+  end
+
+  it "does not modify uids/no_uids if set explicitly via command line" do
+    options = OptionsParser.parse(["--no-uids", "--test-run-name", "hello"], NullReporter.new)
+    expect(options.uids).to be(false)
+
+    options = OptionsParser.parse(["--uids"], NullReporter.new)
+    expect(options.uids).to be(true)
+  end
+
+  it "does not modify uids/no_uids if set explicitly via config file" do
+    f = Tempfile.new('config')
+    File.write(f, "no_uids = true")
+    options = OptionsParser.parse(["--config-file", f.path, "--test-run-name", "hello"], Reporter.new([ErrorListener.new]))
+    expect(options.uids).to be_falsy
+
+    File.write(f, "uids = true")
+    options = OptionsParser.parse(["--config-file", f.path], NullReporter.new)
+    expect(options.uids).to be_truthy
+  end
 end
 
 describe CliOptions do

--- a/spec/render/groovy_spec.rb
+++ b/spec/render/groovy_spec.rb
@@ -341,7 +341,7 @@ describe 'Render as Groovy' do
 
     @scenario_with_datatable_rendered = [
       '',
-      '@Unroll("check login #hiptestUid")',
+      '@Unroll("check login")',
       'def "check login"() {',
       '  // Ensure the login process',
       '',
@@ -353,10 +353,10 @@ describe 'Render as Groovy' do
       '  actionwords.assertErrorIsDisplayed(expected)',
       '',
       '  where:',
-      '  login | password | expected | hiptestUid',
-      '  "invalid" | "invalid" | "Invalid username or password" | "uid:"',
-      '  "valid" | "invalid" | "Invalid username or password" | "uid:"',
-      '  "valid" | "valid" | null | "uid:"',
+      '  login | password | expected',
+      '  "invalid" | "invalid" | "Invalid username or password"',
+      '  "valid" | "invalid" | "Invalid username or password"',
+      '  "valid" | "valid" | null',
       '}'
     ].join("\n")
 
@@ -392,7 +392,7 @@ describe 'Render as Groovy' do
       '  def actionwords = Actionwords.newInstance()',
       '',
       '',
-      '  @Unroll("check login #hiptestUid")',
+      '  @Unroll("check login")',
       '  def "check login"() {',
       '    // Ensure the login process',
       '',
@@ -404,10 +404,10 @@ describe 'Render as Groovy' do
       '    actionwords.assertErrorIsDisplayed(expected)',
       '',
       '    where:',
-      '    login | password | expected | hiptestUid',
-      '    "invalid" | "invalid" | "Invalid username or password" | "uid:"',
-      '    "valid" | "invalid" | "Invalid username or password" | "uid:"',
-      '    "valid" | "valid" | null | "uid:"',
+      '    login | password | expected',
+      '    "invalid" | "invalid" | "Invalid username or password"',
+      '    "valid" | "invalid" | "Invalid username or password"',
+      '    "valid" | "valid" | null',
       '  }',
       '}'
     ].join("\n")
@@ -654,6 +654,7 @@ describe 'Render as Groovy' do
         # only to select the right config group: we render [actionwords], [tests] and others differently
         language: 'groovy',
         framework: 'spock',
+        uids: true,
         with_folders: true)
 
       expect(container.render(render_context)).to eq([
@@ -857,6 +858,7 @@ describe 'Render as Groovy' do
           # only to select the right config group: we render [actionwords], [tests] and others differently
           language: 'groovy',
           framework: 'spock',
+          uids: true,
           with_folders: true)
 
       expect(container.render(render_context)).to eq([
@@ -898,6 +900,57 @@ describe 'Render as Groovy' do
         '    x | y | hiptestUid',
         '    "1" | "2" | "uid:"',
         '    "3" | "4" | "uid:"',
+        '  }',
+        '}',
+      ].join("\n"))
+
+      render_context_without_uids = context_for(
+          node: container,
+          # only to select the right config group: we render [actionwords], [tests] and others differently
+          language: 'groovy',
+          framework: 'spock',
+          uids: false,
+          with_folders: true)
+
+      expect(container.render(render_context_without_uids)).to eq([
+        'package com.example',
+        '',
+        'import spock.lang.*',
+        '',
+        'class SpockUnrollVariantsSpec extends Specification {',
+        '  def actionwords = Actionwords.newInstance()',
+        '',
+        '',
+        '',
+        '',
+        '  @Unroll("When-Then Scenario")',
+        '  def "When-Then Scenario"() {',
+        '',
+        '    given:',
+        '    actionwords.goToPage()',
+        '    when:',
+        '    actionwords.someTrigger()',
+        '    then:',
+        '    actionwords.thePageContainsSomething()',
+        '',
+        '    where:',
+        '    x | y',
+        '    "1" | "2"',
+        '    "3" | "4"',
+        '  }',
+        '',
+        '  @Unroll("Expect Scenario")',
+        '  def "Expect Scenario"() {',
+        '',
+        '    given:',
+        '    actionwords.goToPage()',
+        '    expect:',
+        '    actionwords.thePageContainsSomething()',
+        '',
+        '    where:',
+        '    x | y',
+        '    "1" | "2"',
+        '    "3" | "4"',
         '  }',
         '}',
       ].join("\n"))

--- a/spec/render/jbehave_spec.rb
+++ b/spec/render/jbehave_spec.rb
@@ -227,7 +227,7 @@ describe 'JBehave rendering' do
 
     let(:scenario_with_datatable_rendered) {
       [
-        "Scenario: Create secondary colors#{outline_title_ending}",
+        "Scenario: Create secondary colors",
         "This scenario has a datatable and a description",
         "Given the color \"<first_color>\"",
         "And the color \"<second_color>\"",
@@ -235,17 +235,17 @@ describe 'JBehave rendering' do
         "Then you obtain \"<got_color>\"",
         "",
         "Examples:",
-        "| first_color | second_color | got_color | priority | hiptest-uid |",
-        "| blue | yellow | green | -1 |  |",
-        "| yellow | red | orange | 1 |  |",
-        "| red | blue | purple | true |  |",
+        "| first_color | second_color | got_color | priority |",
+        "| blue | yellow | green | -1 |",
+        "| yellow | red | orange | 1 |",
+        "| red | blue | purple | true |",
         "",
       ].join("\n")
     }
 
     let(:scenario_with_datatable_and_dataset_names_rendered) {
       [
-        "Scenario: Create secondary colors#{outline_title_ending}",
+        "Scenario: Create secondary colors",
         "This scenario has a datatable and a description",
         "Given the color \"<first_color>\"",
         "And the color \"<second_color>\"",
@@ -253,10 +253,10 @@ describe 'JBehave rendering' do
         "Then you obtain \"<got_color>\"",
         "",
         "Examples:",
-        "| dataset name | first_color | second_color | got_color | priority | hiptest-uid |",
-        "| Mix to green | blue | yellow | green | -1 |  |",
-        "| Mix to orange | yellow | red | orange | 1 |  |",
-        "| Mix to purple | red | blue | purple | true |  |",
+        "| dataset name | first_color | second_color | got_color | priority |",
+        "| Mix to green | blue | yellow | green | -1 |",
+        "| Mix to orange | yellow | red | orange | 1 |",
+        "| Mix to purple | red | blue | purple | true |",
         "",
       ].join("\n")
     }
@@ -325,7 +325,7 @@ describe 'JBehave rendering' do
 
     let(:scenario_using_variables_in_step_datatables_rendered) {
       [
-        "Scenario: Check users#{outline_title_ending}",
+        "Scenario: Check users",
         'When I login as',
         '| <username> |',
         'Then I am logged in as',
@@ -334,50 +334,50 @@ describe 'JBehave rendering' do
         '"""',
         '',
         'Examples:',
-        '| username | hiptest-uid |',
-        '| user@example.com |  |',
+        '| username |',
+        '| user@example.com |',
         ''
       ].join("\n")
     }
 
     let(:scenario_with_double_quotes_in_datatable_rendered) {
       [
-        "Scenario: Double quote in datatable#{outline_title_ending}",
+        "Scenario: Double quote in datatable",
         'Given the color "<color_definition>"',
         '',
         'Examples:',
-        '| color_definition | hiptest-uid |',
-        '| {"html": ["#008000", "#50D050"]} |  |',
-        '| {"html": ["#D14FD1"]} |  |',
+        '| color_definition |',
+        '| {"html": ["#008000", "#50D050"]} |',
+        '| {"html": ["#D14FD1"]} |',
         ''
         ].join("\n")
     }
 
     let(:scenario_with_capital_parameters_rendered) {
       [
-        "Scenario: Validate Nav#{outline_title_ending}",
+        "Scenario: Validate Nav",
         'Given I am on the "<SITE_NAME>" home page',
         '',
         'Examples:',
-        '| SITE_NAME | hiptest-uid |',
-        '| http://google.com |  |',
+        '| SITE_NAME |',
+        '| http://google.com |',
         ''
         ].join("\n")
     }
 
     let(:scenario_with_incomplete_datatable_rendered) {
       [
-        "Scenario: Incomplete datatable#{outline_title_ending}",
+        "Scenario: Incomplete datatable",
         'Given the color "<first_color>"',
         'And the color "<second_color>"',
         'When you mix colors',
         'Then you obtain "<got_color>"',
         '',
         'Examples:',
-        '| first_color | second_color | got_color | hiptest-uid |',
-        '| blue | yellow | green |  |',
-        '| yellow | red |  |  |',
-        '| red |  |  |  |',
+        '| first_color | second_color | got_color |',
+        '| blue | yellow | green |',
+        '| yellow | red |  |',
+        '| red |  |  |',
         ''
         ].join("\n")
     }
@@ -439,7 +439,7 @@ describe 'JBehave rendering' do
       ].join("\n")
     }
 
-    let(:feature_rendered_with_option_no_uid) {
+    let(:feature_rendered_with_option_no_uids) {
       [
         "Scenario: Create secondary colors",
         "This scenario has a datatable and a description",
@@ -457,7 +457,7 @@ describe 'JBehave rendering' do
         ].join("\n")
     }
 
-    let(:scenario_rendered_with_option_no_uid) {
+    let(:scenario_rendered_with_option_no_uids) {
       [
         "Scenario: Create secondary colors",
         "This scenario has a datatable and a description",
@@ -480,7 +480,7 @@ describe 'JBehave rendering' do
         'Given I have colors to mix',
         'And I know the expected color',
         '',
-        "Scenario: Create secondary colors#{outline_title_ending}",
+        "Scenario: Create secondary colors",
         'This scenario has a datatable and a description',
         'Given the color "<first_color>"',
         'And the color "<second_color>"',
@@ -488,10 +488,10 @@ describe 'JBehave rendering' do
         'Then you obtain "<got_color>"',
         '',
         'Examples:',
-        '| first_color | second_color | got_color | priority | hiptest-uid |',
-        '| blue | yellow | green | -1 |  |',
-        '| yellow | red | orange | 1 |  |',
-        '| red | blue | purple | true |  |',
+        '| first_color | second_color | got_color | priority |',
+        '| blue | yellow | green | -1 |',
+        '| yellow | red | orange | 1 |',
+        '| red | blue | purple | true |',
         '',
         ''
         ].join("\n")


### PR DESCRIPTION
## Motivation and description of the pull request

There is no point at exporting an extra column with uids when they can't
be fetched because no test run has been specified. So now the default is
to not have uids exported unless `--test-run-id` or `--test-run-name` is
used.

Of course this default behavior can be overriden by specifying `--uids`
or `--no-uids` on command line or in config file.

This will give cleaner feature files on CucumberStudio side.

related to SmartBear/cucumberstudio-issue-tracker#166

## Type of change

- [ ] Breaking change (loosing support of old ruby versions, incompatibility with previous templates or config files)
- [x] New functionality
- [ ] Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [x] Documentation has been added
