### PR TITLE
Remove support for ruby 2.3 and 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,24 +33,6 @@ commands:
           path: /tmp/test-results/<< parameters.output_dir >>
 
 jobs:
-  build-ruby-2_3:
-    docker:
-      - image: circleci/ruby:2.3.8
-
-    working_directory: ~/repo
-    steps:
-      - build_and_test:
-        output_dir: "2.3"
-
-  build-ruby-2_4:
-    docker:
-      - image: circleci/ruby:2.4.5
-
-    working_directory: ~/repo
-    steps:
-      - build_and_test:
-        output_dir: "2.4"
-
   build-ruby-2_5:
     docker:
       - image: circleci/ruby:2.5.5
@@ -73,7 +55,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - build-ruby-2_3
-      - build-ruby-2_4
       - build-ruby-2_5
       - build-ruby-2_6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 rvm:
   - 2.6.2
   - 2.5.5
-  - 2.4.5
-  - 2.3.8
 sudo: false
 before_install:
   - gem update --system # https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ HipTest Publisher Changelog
   - Add support for Cucumber Expression in Java and Groovy  (#205 by tenpaiyomi)
   - Fix possible duplication of actionwords in export (#232 by tenpaiyomi)
   - Breaking change: Export with cucumber expressions are now the default when specifying `--language=cucumber` for TypeScript, Java, and GroovySet. Use `--language=cucumber_legacy` to keep previous export behavior (#205 by tenpaiyomi) (#205 by tenpaiyomi)
+  - Breaking change: Drop support for ruby 2.3 and ruby 2.4 as they have reached end of life
 
 [2.4.0]
 -------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ skip_tags: true
 
 environment:
   matrix:
-    - RUBY_VERSION: "24-x64"
-    - RUBY_VERSION: "24"
     - RUBY_VERSION: "25-x64"
     - RUBY_VERSION: "25"
 

--- a/bin/hiptest-publisher
+++ b/bin/hiptest-publisher
@@ -16,14 +16,18 @@ require 'ruby_version'
 require 'hiptest-publisher/i18n'
 require 'hiptest-publisher/utils'
 
-# Ensure ruby version >= 2.3
-if RubyVersion < '2.3.0'
-  STDERR.puts(I18n.t('ruby_version.required_version', version: '2.3.0'))
+# Ensure ruby version >= 2.5
+if RubyVersion < '2.5.0'
+  STDERR.puts(I18n.t('ruby_version.required_version', version: '2.5.0'))
   STDERR.puts(I18n.t('ruby_version.current_version', engine: RUBY_ENGINE, version: RUBY_VERSION))
   STDERR.puts(I18n.t('ruby_version.use_more_recent'))
 
+  if RubyVersion.is? 2.4
+    STDERR.puts(I18n.('ruby_version.support_ended', version: '2.4.0', year: '2020', month: '03', day: '31'))
+  if RubyVersion.is? 2.3
+    STDERR.puts(I18n.('ruby_version.support_ended', version: '2.3.0', year: '2019', month: '03', day: '31'))
   if RubyVersion.is? 2.2
-    STDERR.puts(I18n.('ruby_version.support_ended', version: '2.2.0', year: '2018', month: '06', day: '20'))
+    STDERR.puts(I18n.('ruby_version.support_ended', version: '2.2.0', year: '2018', month: '03', day: '31'))
   elsif RubyVersion.is? 2.1
     STDERR.puts(I18n.('ruby_version.support_ended', version: '2.1.0', year: '2017', month: '04', day: '01'))
   elsif RubyVersion.is? 2.0
@@ -36,7 +40,7 @@ if RubyVersion < '2.3.0'
   exit 1
 end
 
-if RubyVersion < '2.4'
+if RubyVersion < '2.4' # TODO: deprecate ruby 2.5 (eol 2021-03-31)
   STDERR.puts(I18n.t('ruby_version.current_version', engine: RUBY_ENGINE, version: RUBY_VERSION))
   STDERR.puts(I18n.t('ruby_version.deprecation_warning', version: '2.3'))
   STDERR.puts(I18n.t('ruby_version.support_ended', version: '2.3', year: '2019', month: '03', day: '31'))


### PR DESCRIPTION
Some gems cannot be upgraded because they do not support these versions which have reached end of life

## Motivation and description of the pull request

A link to the issue (for bugfixes) or a description of the new feature.

## Type of change

- [x] Breaking change (loosing support of old ruby versions, incompatibility with previous templates or config files)
- [ ] New functionality
- [ ] Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [x] Documentation has been added
