### PR TITLE
Add windows to continuous integration platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       run: bundle exec bin\hiptest-publisher --help
 
     - name: Run hiptest-publisher --help locally (linux/macos only)
-      if: !contains(matrix.os, 'windows')
+      if: !contains(matrix.os , 'windows')
       env:
         RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
       run: bundle exec bin/hiptest-publisher --help

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
       run: bundle exec bin\hiptest-publisher --help
 
-      - name: Run hiptest-publisher --help locally (linux/macos only)
+    - name: Run hiptest-publisher --help locally (linux/macos only)
       if: !contains(matrix.os, 'windows')
       env:
         RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,11 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-    - name: Run hiptest-publisher --help locally (windows only)
-      if: "contains(matrix.os, 'windows')"
-      env:
-        RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
-      run: bundle exec bin\hiptest-publisher --help
+    # - name: Run hiptest-publisher --help locally (windows only)
+    #   if: "contains(matrix.os, 'windows')"
+    #   env:
+    #     RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
+    #   run: bundle exec bin\hiptest-publisher --help
 
     - name: Run hiptest-publisher --help locally (linux/macos only)
       if: "!contains(matrix.os, 'windows')"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,9 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Run hiptest-publisher --help locally
-      run: RUBYOPT="-Ilib" bundle exec bin/hiptest-publisher --help
+      env:
+        RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
+      run: bundle exec bin/hiptest-publisher --help
 
     - name: RSpec
       run: bundle exec rspec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: [2.5, 2.6]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Run hiptest-publisher --help locally
-      run: bundle exec ruby -I lib bin/hiptest-publisher --help
+      run: RUBYOPT="-Ilib" bundle exec bin/hiptest-publisher --help
 
     - name: RSpec
       run: bundle exec rspec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,14 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-    - name: Run hiptest-publisher --help locally
+    - name: Run hiptest-publisher --help locally (windows only)
+      if: contains(matrix.os, 'windows')
+      env:
+        RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
+      run: bundle exec bin\hiptest-publisher --help
+
+      - name: Run hiptest-publisher --help locally (linux/macos only)
+      if: !contains(matrix.os, 'windows')
       env:
         RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
       run: bundle exec bin/hiptest-publisher --help

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,13 +27,13 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Run hiptest-publisher --help locally (windows only)
-      if: contains(matrix.os, 'windows')
+      if: "contains(matrix.os, 'windows')"
       env:
         RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
       run: bundle exec bin\hiptest-publisher --help
 
     - name: Run hiptest-publisher --help locally (linux/macos only)
-      if: !contains(matrix.os , 'windows')
+      if: "!contains(matrix.os, 'windows')"
       env:
         RUBYOPT: "-Ilib" # include lib/ directory to ruby LOAD_PATH
       run: bundle exec bin/hiptest-publisher --help


### PR DESCRIPTION
## Motivation and description of the pull request

Currently Windows platform is tested with AppVeyor. It would be great to manage everything with GitHub Actions.

## Type of change

- [ ] Breaking change (loosing support of old ruby versions, incompatibility with previous templates or config files)
- [ ] New functionality
- [ ] Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added
