### PR TITLE
Fixed: CVE-2022-31163 (High) detected in tzinfo-1.2.9.gem #307

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     thread_safe (0.3.6)
-    tzinfo (1.2.9)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     webmock (3.14.0)
       addressable (>= 2.8.0)


### PR DESCRIPTION
## Motivation and description of the pull request

[BDD-731: CVE-2022-31163 (High) detected in tzinfo-1.2.9.gem #307](https://smartbear.atlassian.net/browse/BDD-731)

## Type of change

- [x] Breaking change (loosing support of old ruby versions, incompatibility with previous templates or config files)
- [ ] New functionality
- [ ] Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added
