### PR TITLE
Updated new Domain change

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Note: for Windows users, take a look at [this Windows installation guide](docs/I
 Exporting a project
 -------------------
 
-Go to [CucumberStudio projects list](https://studio.cucumber.io/projects), pick one project, and select the Settings tab.
+Go to [CucumberStudio projects list](https://studio.cucumberstudio.com/projects), pick one project, and select the Settings tab.
 This tab is available only for projects you're admin of.
 From there, copy the secret token and run this command line:
 
@@ -83,7 +83,7 @@ When publishing, you'll notice a file called ``actionwords_signature.yaml``. Sto
 Exporting a test run
 --------------------
 
-You can generate the test suite from a test run of your project by specifying option `--test-run-id=<xxx>` when calling `hiptest-publisher`. You can find the test run id in the address bar of your browser. If your browser address is `https://studio.cucumber.io/projects/1234/testRuns/6941`, then your test run id is `6941`. You can generate your tests from your test with this command line:
+You can generate the test suite from a test run of your project by specifying option `--test-run-id=<xxx>` when calling `hiptest-publisher`. You can find the test run id in the address bar of your browser. If your browser address is `https://studio.cucumberstudio.com/projects/1234/testRuns/6941`, then your test run id is `6941`. You can generate your tests from your test with this command line:
 
 ```shell
 hiptest-publisher --token=<YOUR TOKEN> --test-run-id=6941
@@ -136,7 +136,7 @@ Specific options:
         --empty-folders              Export empty folders (default: false)
         --split-scenarios            Export each scenario in a single file (except for Gherkin based languages) (default: false)
         --leafless-export            Use only last level action word (default: false)
-    -s, --site=SITE                  Site to fetch from (default: https://studio.cucumber.io)
+    -s, --site=SITE                  Site to fetch from (default: https://studio.cucumberstudio.com)
     -p, --push=FILE.TAP              Push a results file to the server
         --global-failure-on-missing-reports
                                      When there is no results file to push, report a global failure (default: false)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing
 
 Do not hesitate to contribute to the project by adding support for your favorite language or test framework as explained below. This tool was built to be configurable and have the possibility to export tests in any language.
 
-We did our best to make it as simple as possible, but some knowledge of ruby, handlebars and [HipTest test description language](https://studio.cucumber.io/tdl_documentation.html) is needed to add support for new languages/frameworks.
+We did our best to make it as simple as possible, but some knowledge of ruby, handlebars and [HipTest test description language](https://studio.cucumberstudio.com/tdl_documentation.html) is needed to add support for new languages/frameworks.
 
 Adding support for a new language
 ---------------------------------

--- a/lib/hiptest-publisher/options_parser.rb
+++ b/lib/hiptest-publisher/options_parser.rb
@@ -252,7 +252,7 @@ class OptionsParser
       Option.new(nil, 'empty-folders', false, nil, I18n.t('options.empty_folders'), :empty_folders),
       Option.new(nil, 'split-scenarios', false, nil, I18n.t('options.split_scenarios'), :split_scenarios),
       Option.new(nil, 'leafless-export', false, nil, I18n.t('options.leafless_export'), :leafless_export),
-      Option.new('s', 'site=SITE', 'https://studio.cucumber.io', String, I18n.t('options.site'), :site),
+      Option.new('s', 'site=SITE', 'https://studio.cucumberstudio.com', String, I18n.t('options.site'), :site),
       Option.new(nil, 'http-proxy=PROXY_URL', nil, String, I18n.t('options.http_proxy'), :http_proxy),
       Option.new('p', 'push=FILE.TAP', '', String, I18n.t('options.push'), :push),
       Option.new(nil, 'global-failure-on-missing-reports', false, nil, I18n.t('options.global_failure_on_missing_reports'), :global_failure_on_missing_reports),

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -38,7 +38,7 @@ describe Hiptest::Client do
 
   def stub_available_test_runs(test_runs:, token: "123456789")
     test_runs_json = { test_runs: test_runs }.to_json
-    stub_request(:get, "https://studio.cucumber.io/publication/#{token}/test_runs").
+    stub_request(:get, "https://studio.cucumberstudio.com/publication/#{token}/test_runs").
       to_return(body: test_runs_json,
                 headers: {'Content-Type' => 'application/json'})
   end
@@ -48,7 +48,7 @@ describe Hiptest::Client do
       let(:args) { ["--token", "1234"] }
 
       it 'creates url for tests generation' do
-        expect(client.url).to eq("https://studio.cucumber.io/publication/1234/project")
+        expect(client.url).to eq("https://studio.cucumberstudio.com/publication/1234/project")
       end
 
       context "and with --test-run-id" do
@@ -56,7 +56,7 @@ describe Hiptest::Client do
 
         it 'creates url for tests generation from a test run id' do
           stub_available_test_runs(test_runs: [tr_98__Sprint_13], token: "1234")
-          expect(client.url).to eq("https://studio.cucumber.io/publication/1234/test_run/98")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/1234/test_run/98")
         end
 
         context 'and with --filter-on-status' do
@@ -64,7 +64,7 @@ describe Hiptest::Client do
 
           it 'creates a url to download only tests matching the status' do
             stub_available_test_runs(test_runs: [tr_98__Sprint_13], token: "1234")
-            expect(client.url).to eq("https://studio.cucumber.io/publication/1234/test_run/98?filter_status=passed")
+            expect(client.url).to eq("https://studio.cucumberstudio.com/publication/1234/test_run/98?filter_status=passed")
           end
         end
       end
@@ -73,14 +73,14 @@ describe Hiptest::Client do
         let(:args) { ["--token", "1234", "--push", "myfile.tap"] }
 
         it 'creates url to push results' do
-          expect(client.url).to eq("https://studio.cucumber.io/import_test_results/1234/tap")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/import_test_results/1234/tap")
         end
 
         context "and with --execution-environment" do
           let(:args) { ["--token", "1234", "--push", "myfile.tap", "--execution-environment", "Default"] }
 
           it 'creates url to import results for a specific execution environment' do
-            expect(client.url).to eq("https://studio.cucumber.io/import_test_results/1234/tap?execution_environment=Default")
+            expect(client.url).to eq("https://studio.cucumberstudio.com/import_test_results/1234/tap?execution_environment=Default")
           end
         end
 
@@ -88,7 +88,7 @@ describe Hiptest::Client do
           let(:args) { ["--token", "1234", "--push", "myfile.tap", "--build-name", "My named build"] }
 
           it 'creates url to import results for a specific execution environment' do
-            expect(client.url).to eq("https://studio.cucumber.io/import_test_results/1234/tap?build_name=My%20named%20build")
+            expect(client.url).to eq("https://studio.cucumberstudio.com/import_test_results/1234/tap?build_name=My%20named%20build")
           end
         end
 
@@ -96,7 +96,7 @@ describe Hiptest::Client do
           let(:args) { ["--token", "1234", "--push", "myfile.tap", "--build-id", "456"] }
 
           it 'creates url to import results for a specific execution environment' do
-            expect(client.url).to eq("https://studio.cucumber.io/import_test_results/1234/tap?build_id=456")
+            expect(client.url).to eq("https://studio.cucumberstudio.com/import_test_results/1234/tap?build_id=456")
           end
         end
       end
@@ -105,7 +105,7 @@ describe Hiptest::Client do
         let(:args) {['--token', '123', '--filter-on-scenario-ids', '1, 3, 4']}
 
         it 'creates a url specifying the filter' do
-          expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_scenario_ids=1,3,4")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_scenario_ids=1,3,4")
         end
       end
 
@@ -113,19 +113,19 @@ describe Hiptest::Client do
         let(:args) {['--token', '123', '--filter-on-scenario-name', 'My scenario']}
 
         it 'creates a url specifying the filter' do
-          expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_scenario_name=My%20scenario")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_scenario_name=My%20scenario")
         end
 
         it 'escapes the name for the URL' do
           # args = ['--token', '123', '--filter-on-scenario-name', 'My pouet scenario']
           args[-1] = %q{It's "escaped"_%42_😎_<>}
-          expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_scenario_name=It%27s%20%22escaped%22_%2542_%F0%9F%98%8E_%3C%3E")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_scenario_name=It%27s%20%22escaped%22_%2542_%F0%9F%98%8E_%3C%3E")
         end
 
         it 'escapes accentuated letters for the URL' do
           # args = ['--token', '123', '--filter-on-scenario-name', 'My pouet scenario']
           args[-1] = "La qualité est clé"
-          expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_scenario_name=La%20qualit%C3%A9%20est%20cl%C3%A9")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_scenario_name=La%20qualit%C3%A9%20est%20cl%C3%A9")
         end
       end
 
@@ -133,14 +133,14 @@ describe Hiptest::Client do
         let(:args) {['--token', '123', '--filter-on-folder-ids', '7, 8, 10']}
 
         it 'creates a url specifying the filter' do
-          expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_folder_ids=7,8,10")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_folder_ids=7,8,10")
         end
 
         context '--not-recursive' do
           let(:args) {['--token', '123', '--filter-on-folder-ids', '7, 8, 10', '--not-recursive']}
 
           it 'allows enabling the not_recursive option' do
-            expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_folder_ids=7,8,10&not_recursive=true")
+            expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_folder_ids=7,8,10&not_recursive=true")
           end
         end
       end
@@ -149,14 +149,14 @@ describe Hiptest::Client do
         let(:args) {['--token', '123', '--filter-on-folder-name', 'My super folder']}
 
         it 'creates a url specifying the filter' do
-          expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_folder_name=My%20super%20folder")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_folder_name=My%20super%20folder")
         end
 
         context '--not-recursive' do
           let(:args) {['--token', '123', '--filter-on-folder-name', 'My super folder', '--not-recursive']}
 
           it 'allows enabling the not_recursive option' do
-            expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_folder_name=My%20super%20folder&not_recursive=true")
+            expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_folder_name=My%20super%20folder&not_recursive=true")
           end
         end
       end
@@ -165,7 +165,7 @@ describe Hiptest::Client do
         let(:args) {['--token', '123', '--filter-on-tags', 'tag, another:tag']}
 
         it 'creates a url specifying the filter' do
-          expect(client.url).to eq("https://studio.cucumber.io/publication/123/project?filter_tags=tag,another%3Atag")
+          expect(client.url).to eq("https://studio.cucumberstudio.com/publication/123/project?filter_tags=tag,another%3Atag")
         end
       end
 
@@ -186,20 +186,20 @@ describe Hiptest::Client do
       let(:args) { ["--token", "123456789"] }
 
       before do
-        stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+        stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
             to_return(status: 404)
       end
 
       it 'fetches the project xml from CucumberStudio server' do
         sent_xml = "<xml_everywhere/>"
-        stub_request(:get, "https://studio.cucumber.io/publication/123456789/project").
+        stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project").
           to_return(body: sent_xml)
         got_xml = client.fetch_project
         expect(got_xml).to eq(sent_xml)
       end
 
       context "when a redirection response is given" do
-        let(:original_location) { "https://studio.cucumber.io/publication/123456789/project" }
+        let(:original_location) { "https://studio.cucumberstudio.com/publication/123456789/project" }
         let(:new_location) { "https://hop.hiptest.org/publication/123456789/project" }
 
         before do
@@ -240,14 +240,14 @@ describe Hiptest::Client do
         end
 
         it 'only fetches the XML file from CucumberStudio the first time' do
-          stub_request(:get, "https://studio.cucumber.io/publication/123456789/project").
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project").
             to_return(body: "<xml_everywhere/>")
 
           client.fetch_project
           client.fetch_project
           client.fetch_project
 
-          expect(a_request(:get, "https://studio.cucumber.io/publication/123456789/project"))
+          expect(a_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project"))
             .to have_been_made.at_most_once
         end
       end
@@ -256,12 +256,12 @@ describe Hiptest::Client do
         let(:args) { ["--token", "987654321"] }
 
         before do
-          stub_request(:post, "https://studio.cucumber.io/publication/987654321/async_project").
+          stub_request(:post, "https://studio.cucumberstudio.com/publication/987654321/async_project").
               to_return(status: 404)
         end
 
         it "raises a ClientError exception with a message" do
-          stub_request(:get, "https://studio.cucumber.io/publication/987654321/project").
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/987654321/project").
             to_return(status: 404)
           expect {
             client.fetch_project
@@ -273,7 +273,7 @@ describe Hiptest::Client do
 
           it "raises a ClientError exception with a message" do
             stub_available_test_runs(test_runs: [tr_98__Sprint_13], token: "987654321")
-            stub_request(:get, "https://studio.cucumber.io/publication/987654321/test_run/98").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/987654321/test_run/98").
               to_return(status: 404)
             expect {
               client.fetch_project
@@ -281,9 +281,9 @@ describe Hiptest::Client do
           end
 
           it "raises a ClientError exception with a message (return 404 at another level)" do
-            stub_request(:get, "https://studio.cucumber.io/publication/987654321/test_runs").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/987654321/test_runs").
               to_return(status: 404)
-            stub_request(:get, "https://studio.cucumber.io/publication/987654321/test_run/98").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/987654321/test_run/98").
               to_return(status: 404)
             expect {
               client.fetch_project
@@ -295,7 +295,7 @@ describe Hiptest::Client do
           let(:args) { ["--token", "987654321", "--test-run-name", "plop"] }
 
           it "raises a ClientError exception with a message" do
-            stub_request(:get, "https://studio.cucumber.io/publication/987654321/test_runs").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/987654321/test_runs").
               to_return(status: 404)
             expect {
               client.fetch_project
@@ -310,7 +310,7 @@ describe Hiptest::Client do
         it "fetches the test run xml from CucumberStudio server" do
           stub_available_test_runs(test_runs: [tr_98__Sprint_13])
           sent_xml = "<xml_everywhere/>"
-          stub_request(:get, "https://studio.cucumber.io/publication/123456789/test_run/98").
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/test_run/98").
             to_return(body: sent_xml)
           got_xml = client.fetch_project
           expect(got_xml).to eq(sent_xml)
@@ -342,10 +342,10 @@ describe Hiptest::Client do
 
         context "on old CucumberStudio version (no /publication/<token>/test_runs API)" do
           it "uses the given test run id and ignores that the API does not exist" do
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/test_runs").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/test_runs").
               to_return(status: 404)
             sent_xml = "<xml_everywhere/>"
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/test_run/98").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/test_run/98").
               to_return(body: sent_xml)
             got_xml = client.fetch_project
             expect(got_xml).to eq(sent_xml)
@@ -359,7 +359,7 @@ describe Hiptest::Client do
         it "first fetches the test runs list to get the id, then the test run xml" do
           stub_available_test_runs(test_runs: [tr_89__Sprint_12])
           sent_xml = "<xml_everywhere/>"
-          stub_request(:get, "https://studio.cucumber.io/publication/123456789/test_run/89").
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/test_run/89").
             to_return(body: sent_xml)
           got_xml = client.fetch_project
           expect(got_xml).to eq(sent_xml)
@@ -402,9 +402,9 @@ describe Hiptest::Client do
       context 'when the server does not support async project export' do
         it 'calls the former export url' do
           sent_xml = "<xml_everywhere/>"
-          stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+          stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
               to_return(status: 404)
-          stub_request(:get, "https://studio.cucumber.io/publication/123456789/project").
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project").
               to_return(body: sent_xml)
           got_xml = client.fetch_project
           expect(got_xml).to eq(sent_xml)
@@ -413,14 +413,14 @@ describe Hiptest::Client do
 
       context 'when the server supports async project export' do
         before do
-          stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project")
+          stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project")
             .to_return(:status => 201, :body => { "publication_export_id": 1 }.to_json)
         end
 
         it 'fetches the project xml from CucumberStudio server' do
           sent_xml = "<xml_everywhere/>"
 
-          stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1").
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1").
               to_return(body: sent_xml)
 
           got_xml = client.fetch_project
@@ -430,7 +430,7 @@ describe Hiptest::Client do
         it 'fetches the project xml from CucumberStudio server after many attempts' do
           sent_xml = "<xml_everywhere/>"
 
-          stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1")
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1")
             .to_return(:status => 202)
             .to_return(:status => 202)
             .to_return(body: sent_xml)
@@ -440,7 +440,7 @@ describe Hiptest::Client do
         end
 
         it 'does not try more than max_attempts times' do
-          stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1")
+          stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1")
             .to_return(:status => 202)
             .to_return(:status => 202)
             .to_return(:status => 202)
@@ -451,14 +451,14 @@ describe Hiptest::Client do
 
         context 'when an export was already in progress' do
           before do
-            stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project")
+            stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project")
               .to_return(:status => 202, :body => { "publication_export_id": 1 }.to_json)
           end
 
           it 'waits the end of the export and download it' do
             sent_xml = "<xml_everywhere/>"
 
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1")
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1")
               .to_return(:status => 202)
               .to_return(body: sent_xml)
 
@@ -489,10 +489,10 @@ describe Hiptest::Client do
     end
 
     it 'sends a post request with the file specified in the --push option embedded' do
-      stub_request(:post, "https://studio.cucumber.io/import_test_results/123456789/json")
+      stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/123456789/json")
       client.push_results
 
-      expect(a_request(:post, "https://studio.cucumber.io/import_test_results/123456789/json").
+      expect(a_request(:post, "https://studio.cucumberstudio.com/import_test_results/123456789/json").
         with { |req|
           expect(req.body).to match(/Content-Disposition: form-data;.+ filename="result.json"(.|\n)*#{report_content}.*/)
           expect(req.headers['Content-Type']).to include('multipart/form-data;')
@@ -504,10 +504,10 @@ describe Hiptest::Client do
       let(:pushed_file) { "#{results_dir}/*.json" }
 
       it 'sends multiple files' do
-        stub_request(:post, "https://studio.cucumber.io/import_test_results/123456789/json")
+        stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/123456789/json")
         client.push_results
 
-        expect(a_request(:post, "https://studio.cucumber.io/import_test_results/123456789/json").
+        expect(a_request(:post, "https://studio.cucumberstudio.com/import_test_results/123456789/json").
           with { |req|
             expect(req.body).to match(/Content-Disposition: form-data;.+ filename="result.json"(.|\n)*#{report_content}.*/)
             expect(req.body).to match(/Content-Disposition: form-data;.+ filename="result1.json"(.|\n)*#{second_report_content}*/)
@@ -518,7 +518,7 @@ describe Hiptest::Client do
     end
 
     context "when a redirect response is given" do
-      let(:original_location) { "https://studio.cucumber.io/import_test_results/123456789/json"}
+      let(:original_location) { "https://studio.cucumberstudio.com/import_test_results/123456789/json"}
       let(:new_location) { "https://hop.hiptest.org/import_test_results/123456789/json" }
 
       before do
@@ -553,7 +553,7 @@ describe Hiptest::Client do
     end
 
     context "when there is no file to push" do
-      let(:failure_url) { "https://studio.cucumber.io/report_global_failure/123456789/123/" }
+      let(:failure_url) { "https://studio.cucumberstudio.com/report_global_failure/123456789/123/" }
       let(:pushed_file) { "#{results_dir}/nothing_there.json" }
 
       it "sends a request to notify hiptest" do

--- a/spec/hiptest_publisher_spec.rb
+++ b/spec/hiptest_publisher_spec.rb
@@ -151,11 +151,11 @@ describe Hiptest::Publisher do
 
   describe "--language=ruby" do
     def run_publisher_command(*extra_args)
-      stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+      stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
         to_return(body: { publication_export_id: 1 }.to_json)
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1").
         to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/leafless_tests").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/leafless_tests").
         to_return(body: File.read('samples/xml_input/Hiptest automation.xml'))
       args = [
         "--language", "ruby",
@@ -168,9 +168,9 @@ describe Hiptest::Publisher do
     end
 
     it "exports correctly in the golden case" do
-      stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+      stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
         to_return(body: { publication_export_id: 1 }.to_json)
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1").
         to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
       args = [
         "--language", "ruby",
@@ -184,7 +184,7 @@ describe Hiptest::Publisher do
     end
 
     it "can handle bad URL" do
-      stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+      stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
         to_raise(StandardError)
       args = [
         "--language", "ruby",
@@ -200,9 +200,9 @@ describe Hiptest::Publisher do
     end
 
     it "can handle 404 Not Found errors" do
-      stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+      stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
         to_return(status: 404)
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/project").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project").
         to_return(status: 404)
       args = [
         "--language", "ruby",
@@ -222,9 +222,9 @@ describe Hiptest::Publisher do
 
     context "with a server that does not support async exports" do
       it "exports correctly in the golden case" do
-        stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+        stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
           to_return(status: 404)
-        stub_request(:get, "https://studio.cucumber.io/publication/123456789/project").
+        stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project").
           to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
         args = [
           "--language", "ruby",
@@ -635,7 +635,7 @@ describe Hiptest::Publisher do
     end
 
     before do
-      stub_request(:post, "https://studio.cucumber.io/import_test_results/123/tap").
+      stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/123/tap").
           to_return(status: 200,
                     body: '{"test_import": [{"name": "my test", "status": "passed"}]}')
     end
@@ -646,13 +646,13 @@ describe Hiptest::Publisher do
       publisher = Hiptest::Publisher.new(["--token", "123", "--push", result_file], listeners: listeners)
       publisher.run
 
-      expect(a_request(:post, "https://studio.cucumber.io/import_test_results/123/tap").
+      expect(a_request(:post, "https://studio.cucumberstudio.com/import_test_results/123/tap").
         with { |req|
           expect(req.body).to match(/Content-Disposition: form-data;.+ filename="result.tap"/)
           expect(req.headers['Content-Type']).to include('multipart/form-data;')
         }
       ).to have_been_made
-      expect(STDOUT).to have_printed("Posting #{result_file} to https://studio.cucumber.io")
+      expect(STDOUT).to have_printed("Posting #{result_file} to https://studio.cucumberstudio.com")
     end
 
     it "support globbing to push multiple files" do
@@ -663,7 +663,7 @@ describe Hiptest::Publisher do
 
       publisher.run
 
-      expect(a_request(:post, "https://studio.cucumber.io/import_test_results/123/tap").
+      expect(a_request(:post, "https://studio.cucumberstudio.com/import_test_results/123/tap").
         with { |req|
           expect(req.body).to match(/Content-Disposition: form-data;.+ filename="result1.tap"/).
                           and match(/Content-Disposition: form-data;.+ filename="result2.tap"/)
@@ -681,7 +681,7 @@ describe Hiptest::Publisher do
       expect(STDOUT).to have_printed("One test imported\n")
 
       # multiple passed
-      stub_request(:post, "https://studio.cucumber.io/import_test_results/456/tap").
+      stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/456/tap").
           to_return(status: 200,
                     body: '{"test_import": [{"name": "test1", "status": "passed"}, {"name": "test2", "status": "passed"}]}')
       publisher = Hiptest::Publisher.new(["--token", "456", "--push", result_file], listeners: listeners)
@@ -693,7 +693,7 @@ describe Hiptest::Publisher do
 
     it "should display an error if no tests have been imported" do
       result_file = create_file('result.tap')
-      stub_request(:post, "https://studio.cucumber.io/import_test_results/456/tap").
+      stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/456/tap").
           to_return(status: 200,
                     body: '{"test_import": []}')
       publisher = Hiptest::Publisher.new(["--token", "456", "--push", result_file], listeners: listeners)
@@ -705,7 +705,7 @@ describe Hiptest::Publisher do
 
     it "displays names of passed tests with --verbose" do
       result_file = create_file('result.tap')
-      stub_request(:post, "https://studio.cucumber.io/import_test_results/456/tap").
+      stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/456/tap").
           to_return(status: 200,
                     body: '{"test_import": [{"name": "test1", "status": "passed"}, {"name": "test2", "status": "passed"}]}')
 
@@ -718,7 +718,7 @@ describe Hiptest::Publisher do
 
     context 'when no results have been imported' do
       before do
-        stub_request(:post, "https://studio.cucumber.io/import_test_results/456/tap").
+        stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/456/tap").
             to_return(status: 200,
                       body: '{"test_import": []}')
       end
@@ -791,7 +791,7 @@ describe Hiptest::Publisher do
       let(:result_file) { create_file('result.tap') }
 
       before do
-        stub_request(:post, "https://studio.cucumber.io/import_test_results/456/tap").
+        stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/456/tap").
             to_return(status: 404,
                       body: "")
       end
@@ -809,7 +809,7 @@ describe Hiptest::Publisher do
       let(:result_file) { create_file('result.jsonb') }
 
       before do
-        stub_request(:post, "https://studio.cucumber.io/import_test_results/456/jsonb").
+        stub_request(:post, "https://studio.cucumberstudio.com/import_test_results/456/jsonb").
             to_return(status: 422,
                       body: "Unknown format jsonb. Available formats are:" +
                             "\n - android-studio" +
@@ -1112,7 +1112,7 @@ describe Hiptest::Publisher do
 
       context "with option global_failure_on_missing_reports on" do
         before(:each) {
-          stub_request(:post, "https://studio.cucumber.io/report_global_failure/123/456/").
+          stub_request(:post, "https://studio.cucumberstudio.com/report_global_failure/123/456/").
             to_return(body: '{"test_import": [{"name": "Simple use", "status": "failed"}]}')
         }
 
@@ -1146,9 +1146,9 @@ describe Hiptest::Publisher do
 
     context "--output-directory" do
       before(:each) {
-        stub_request(:post, "https://studio.cucumber.io/publication/123/async_project").
+        stub_request(:post, "https://studio.cucumberstudio.com/publication/123/async_project").
           to_return(body: { publication_export_id: 1 }.to_json)
-        stub_request(:get, "https://studio.cucumber.io/publication/123/async_project/1").
+        stub_request(:get, "https://studio.cucumberstudio.com/publication/123/async_project/1").
           to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
       }
 
@@ -1286,9 +1286,9 @@ describe Hiptest::Publisher do
 
   describe "--language=seleniumide" do
     def run_publisher_command(*extra_args)
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/project").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project").
         to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/leafless_tests").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/leafless_tests").
         to_return(body: File.read('samples/xml_input/Hiptest automation.xml'))
       args = [
         "--language", "seleniumide",
@@ -1309,9 +1309,9 @@ describe Hiptest::Publisher do
   describe "--filename-pattern" do
     # Only works --with-folders
     def run_publisher_command(*extra_args)
-      stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+      stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
         to_return(body: { publication_export_id: 1 }.to_json)
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1").
         to_return(body: File.read('samples/xml_input/cash_withdrawal.xml'))
       args = [
         "--language", "javascript",

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -63,17 +63,17 @@ describe Hiptest::Publisher do
           assertion_text <<  " --framework=#{framework}" if framework
           it assertion_text do
             test_runs_json = { test_runs: [{id: "987",name: "Sprint 1"}] }.to_json
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/test_runs").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/test_runs").
               to_return(body: test_runs_json, headers: {'Content-Type' => 'application/json'})
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/project").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/project").
               to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
-            stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+            stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
               to_return(body: { publication_export_id: 1 }.to_json)
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1").
               to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/test_run/987").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/test_run/987").
               to_return(body: File.read('samples/xml_input/Hiptest test run.xml'))
-            stub_request(:get, "https://studio.cucumber.io/publication/123456789/leafless_tests").
+            stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/leafless_tests").
               to_return(body: File.read('samples/xml_input/Hiptest automation.xml'))
             args = [
               "--language", language,
@@ -100,9 +100,9 @@ describe Hiptest::Publisher do
 
     before(:each) {
       File.write("#{templates_dir}/scenarios.hbs", "This is a custom template referencing meta:custom {{ context.meta.custom }}")
-      stub_request(:post, "https://studio.cucumber.io/publication/123456789/async_project").
+      stub_request(:post, "https://studio.cucumberstudio.com/publication/123456789/async_project").
         to_return(body: { publication_export_id: 1 }.to_json)
-      stub_request(:get, "https://studio.cucumber.io/publication/123456789/async_project/1").
+      stub_request(:get, "https://studio.cucumberstudio.com/publication/123456789/async_project/1").
         to_return(body: File.read('samples/xml_input/Hiptest publisher.xml'))
     }
 


### PR DESCRIPTION
## Updated new Domain change for CucumberStudio

## Changed hardcoded URL from studio.cucumber.io to studio.cucmberstudio.com

- [No] Breaking change (loosing support of old ruby versions, incompatibility with previous templates or config files)
- [No] New functionality
- [No] Bug fix
